### PR TITLE
chore: update .golangci.yaml

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,22 +8,24 @@ run:
 linters:
   default: all
   disable:
-    - wsl
     - depguard
     - exhaustruct
     - ginkgolinter
     - gochecknoglobals
     - gochecknoinits
     - godot
-    - musttag
-    - nlreturn
-    - tagalign
-    - mnd
-    - varnamelen
-    - wrapcheck
     - ireturn
+    - interfacebloat
+    - musttag
+    - mnd
+    - nlreturn
     - noctx
     - noinlineerr
+    - revive
+    - tagalign
+    - varnamelen
+    - wrapcheck
+    - wsl
     - wsl_v5
   settings:
     paralleltest:
@@ -41,6 +43,13 @@ linters:
       # This creates a lint error if there isn't an explicit case for all values of
       # enum without a default
       default-signifies-exhaustive: true
+    revive:
+      rules:
+        - name: var-naming
+          arguments:
+            - [] # AllowList
+            - [] # DenyList
+            - - skip-package-name-collision-with-go-std: true
   exclusions:
     generated: lax
     presets:
@@ -55,10 +64,14 @@ linters:
         source: ^func [Tt]est|Benchmark
       - linters:
           - unqueryvet
+          - gocognit
+          - cyclop
         path: benchmark/.*
       - linters:
           - funcorder
           - dupl
+          - funlen
+          - lll
         path: (.+)_test\.go
       - linters:
           - contextcheck
@@ -66,6 +79,10 @@ linters:
       - linters:
           - contextcheck
         path: (.+)crypto_test\.go
+      - linters:
+          - contextcheck
+          - fatcontext
+        path: (.+)workflow_test\.go
     paths:
       - third_party$
       - builtin$

--- a/Makefile
+++ b/Makefile
@@ -541,6 +541,7 @@ generate-task-proto:
 		--go-grpc_out=. \
 		--go-grpc_opt=paths=source_relative \
 		internal/event-processor/proto/*.proto
+	goimports -w -local=github.com/openkcm/cmk internal/event-processor/proto/*.pb.go
 
 tenant-cli:
 	kubectl exec -it -n cmk deploy/cmk-tenant-manager-cli -- ./bin/tenant-manager-cli $(ARGS)

--- a/internal/event-processor/proto/task.pb.go
+++ b/internal/event-processor/proto/task.pb.go
@@ -7,11 +7,12 @@
 package proto
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
Update disabled linters on .golangci.yaml 
