### PR TITLE
fix: workflow expiry task

### DIFF
--- a/cmd/task-worker/main.go
+++ b/cmd/task-worker/main.go
@@ -150,6 +150,7 @@ func registerTasks(
 		tasks.NewKeystorePoolFiller(keyManager, r, cfg.KeystorePool),
 		tasks.NewWorkflowProcessor(workflowManager, r),
 		tasks.NewNotificationSender(notificationClient),
+		tasks.NewWorkflowExpiryProcessor(workflowManager, r),
 		tasks.NewWorkflowCleaner(workflowManager, r),
 	})
 

--- a/internal/async/tasks/workflow_expiry_test.go
+++ b/internal/async/tasks/workflow_expiry_test.go
@@ -22,15 +22,26 @@ import (
 	"github.com/openkcm/cmk/utils/ptr"
 )
 
-var ErrWorkflowNotFound = errors.New("workflow not found")
+var (
+	ErrWorkflowNotFound = errors.New("workflow not found")
+	ErrTransitionFailed = errors.New("workflow transition failed")
+	ErrMockGetWorkflows = errors.New("forced GetWorkflows error")
+	ErrMockTransition   = errors.New("forced TransitionWorkflow error")
+)
 
 type WorkflowExpiryMock struct {
-	repo repo.Repo
+	repo          repo.Repo
+	getErr        error
+	transitionErr error
 }
 
 func (s *WorkflowExpiryMock) GetWorkflows(ctx context.Context,
 	params repo.QueryMapper,
 ) ([]*model.Workflow, int, error) {
+	if s.getErr != nil {
+		return nil, 0, s.getErr
+	}
+
 	workflows := []*model.Workflow{}
 
 	count, err := s.repo.List(ctx, model.Workflow{}, &workflows, *params.GetQuery(ctx))
@@ -41,17 +52,28 @@ func (s *WorkflowExpiryMock) GetWorkflows(ctx context.Context,
 	return workflows, count, nil
 }
 
-func (s *WorkflowExpiryMock) TransitionWorkflow(ctx context.Context, userID uuid.UUID,
-	workflowID uuid.UUID, transition wfMechanism.Transition,
+func (s *WorkflowExpiryMock) TransitionWorkflow(ctx context.Context,
+	workflowID uuid.UUID,
+	transition wfMechanism.Transition,
 ) (*model.Workflow, error) {
+	if s.transitionErr != nil {
+		return nil, s.transitionErr
+	}
+
 	workflows, _, _ := s.GetWorkflows(ctx, manager.WorkflowFilter{})
 	for _, wf := range workflows {
 		if wf.ID == workflowID {
+			if transition != wfMechanism.TransitionExpire {
+				return nil, ErrTransitionFailed
+			}
+
 			wf.State = string(wfMechanism.StateExpired)
+
 			_, err := s.repo.Patch(ctx, wf, *repo.NewQuery())
 			if err != nil {
 				return nil, err
 			}
+
 			return wf, nil
 		}
 	}
@@ -86,10 +108,10 @@ func TestWorkflowExpiresAction(t *testing.T) {
 		),
 	)
 
-	expirer := &WorkflowExpiryMock{r}
-	processor := tasks.NewWorkflowExpiryProcessor(expirer, r)
-
 	t.Run("Sets Expired", func(t *testing.T) {
+		expirer := &WorkflowExpiryMock{r, nil, nil}
+		processor := tasks.NewWorkflowExpiryProcessor(expirer, r)
+
 		task := asynq.NewTask(config.TypeWorkflowExpire, nil)
 		err := processor.ProcessTask(ctx, task)
 		assert.NoError(t, err)
@@ -108,5 +130,26 @@ func TestWorkflowExpiresAction(t *testing.T) {
 		}
 		assert.Equal(t, 2, initStates)
 		assert.Equal(t, 1, expStates)
+	})
+
+	t.Run("GetWorkflows fails", func(t *testing.T) {
+		expirer := &WorkflowExpiryMock{r, ErrMockGetWorkflows, nil}
+		processor := tasks.NewWorkflowExpiryProcessor(expirer, r)
+
+		task := asynq.NewTask(config.TypeWorkflowExpire, nil)
+		err := processor.ProcessTask(ctx, task)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "task failed")
+	})
+
+	t.Run("Transition fails", func(t *testing.T) {
+		// Ensure there is at least one expired workflow to trigger transition.
+		expirer := &WorkflowExpiryMock{r, nil, ErrMockTransition}
+		processor := tasks.NewWorkflowExpiryProcessor(expirer, r)
+
+		task := asynq.NewTask(config.TypeWorkflowExpire, nil)
+		err := processor.ProcessTask(ctx, task)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "task failed")
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add missing task registration in async task worker for workflow automatic expiration.
- Refactor the workflow expiry task
