### PR TITLE
feat: add component-specific resource overrides for deployments

### DIFF
--- a/charts/cmk/Chart.yaml
+++ b/charts/cmk/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.56
+version: 0.1.57
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cmk/templates/api-server/deployment.yaml
+++ b/charts/cmk/templates/api-server/deployment.yaml
@@ -89,7 +89,7 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.resources }}
+          {{- with (default .Values.resources .Values.apiServer.resources) }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/cmk/templates/task-cli/deployment.yaml
+++ b/charts/cmk/templates/task-cli/deployment.yaml
@@ -74,6 +74,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+          {{- with (default .Values.resources .Values.taskCLI.resources) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: {{ include "cmk.name" . }}-task-cli-config-volume
               mountPath: /etc/cmk

--- a/charts/cmk/templates/task-scheduler/deployment.yaml
+++ b/charts/cmk/templates/task-scheduler/deployment.yaml
@@ -81,6 +81,10 @@ spec:
           envFrom:
           {{- . | toYaml | nindent 12 }}
           {{- end}}
+          {{- with (default .Values.resources .Values.taskScheduler.resources) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: {{ include "cmk.name" . }}-task-scheduler-config-volume
               mountPath: /etc/cmk

--- a/charts/cmk/templates/task-worker/deployment.yaml
+++ b/charts/cmk/templates/task-worker/deployment.yaml
@@ -81,6 +81,10 @@ spec:
           envFrom:
           {{- . | toYaml | nindent 12 }}
           {{- end }}
+          {{- with (default .Values.resources .Values.taskWorker.resources) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: {{ include "cmk.name" . }}-task-worker-config-volume
               mountPath: /etc/cmk

--- a/charts/cmk/templates/tenant-manager-cli/deployment.yaml
+++ b/charts/cmk/templates/tenant-manager-cli/deployment.yaml
@@ -74,6 +74,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+          {{- with (default .Values.resources .Values.tenantManagerCLI.resources) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: {{ include "cmk.name" . }}-tenant-manager-cli-config-volume
               mountPath: /etc/tenant-manager-cli

--- a/charts/cmk/templates/tenant-manager/deployment.yaml
+++ b/charts/cmk/templates/tenant-manager/deployment.yaml
@@ -74,6 +74,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+          {{- with (default .Values.resources .Values.tenantManager.resources) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: {{ include "cmk.name" . }}-tenant-manager-config-volume
               mountPath: /etc/tenant-manager

--- a/charts/cmk/values.yaml
+++ b/charts/cmk/values.yaml
@@ -25,6 +25,9 @@ apiServer:
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   topologySpreadConstraints: []
 
+  # Component-specific resources override; falls back to global `resources`.
+  resources: {}
+
 # tenant-manager configuration
 tenantManager:
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
@@ -60,6 +63,9 @@ tenantManager:
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   topologySpreadConstraints: []
 
+  # Component-specific resources override; falls back to global `resources`.
+  resources: {}
+
 # tenant-manager-cli configuration
 tenantManagerCLI:
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
@@ -86,6 +92,9 @@ tenantManagerCLI:
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   topologySpreadConstraints: []
 
+  # Component-specific resources override; falls back to global `resources`.
+  resources: {}
+
 # task scheduler configuration
 taskScheduler:
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
@@ -107,6 +116,9 @@ taskScheduler:
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   topologySpreadConstraints: []
 
+  # Component-specific resources override; falls back to global `resources`.
+  resources: {}
+
 # task worker configuration
 taskWorker:
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
@@ -127,6 +139,9 @@ taskWorker:
   # This is for setting up pod topology spread constraints, more information can be found here:
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   topologySpreadConstraints: []
+
+  # Component-specific resources override; falls back to global `resources`.
+  resources: {}
 
 # task-cli configuration
 taskCLI:
@@ -153,6 +168,17 @@ taskCLI:
   # This is for setting up pod topology spread constraints, more information can be found here:
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
   topologySpreadConstraints: []
+
+  # Component-specific resources override; falls back to global `resources`.
+  resources: {}
+
+# db-migrator configuration
+dbMigrator:
+  image:
+    command: ""
+    args: []
+  # Enable the db-migrator job.
+  deploy: false
 
 # Override the "name" value, which is used to annotate some of
 # the resources that are created by this Chart (using "app.kubernetes.io/name").


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.
- Adds a configurable `resources` block to all deployments.
- Supports per-component `resources` overrides with global fallback.
- Default behavior unchanged unless `resources` are set.
```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.
Add per-component `resources` overrides with global fallback; no change unless configured.
```
