### PR TITLE
fix: keyconfig cert returning exists by default

### DIFF
--- a/internal/manager/certificate.go
+++ b/internal/manager/certificate.go
@@ -330,16 +330,16 @@ func (m *CertificateManager) getCertificateByPurpose(
 
 	cert := &model.Certificate{}
 
-	_, err := m.repo.First(ctx, cert, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(
+	found, err := m.repo.First(ctx, cert, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(
 		compositeKey)).Order(repo.OrderField{
 		Field:     repo.CreationDateField,
 		Direction: repo.Desc,
 	}))
 	if err != nil && !errors.Is(err, repo.ErrNotFound) {
-		return nil, false, errs.Wrap(ErrCertificateManager, err)
+		return nil, found, errs.Wrap(ErrCertificateManager, err)
 	}
 
-	return cert, true, nil
+	return cert, found, nil
 }
 
 func (m *CertificateManager) getNewCertificate(

--- a/internal/manager/certificate_test.go
+++ b/internal/manager/certificate_test.go
@@ -300,6 +300,29 @@ func TestCertificateManager_RotateCertificate(t *testing.T) {
 	assert.Equal(t, gotRot2Cert.ID, rotCerts[0].ID)
 }
 
+func TestGetCertificateByPurpose(t *testing.T) {
+	m, db, tenant := SetupCertificateManager(t)
+	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
+	r := sql.NewRepository(db)
+
+	t.Run("Should return false on cert not exist", func(t *testing.T) {
+		_, exist, err := m.GetCertificateByPurpose(ctx, model.CertificatePurposeTenantDefault)
+		assert.NoError(t, err)
+		assert.False(t, exist)
+	})
+
+	t.Run("Should return true if cert exists", func(t *testing.T) {
+		cert := testutils.NewCertificate(func(c *model.Certificate) {
+			c.Purpose = model.CertificatePurposeTenantDefault
+		})
+		testutils.CreateTestEntities(ctx, t, r, cert)
+		res, exist, err := m.GetCertificateByPurpose(ctx, model.CertificatePurposeTenantDefault)
+		assert.NoError(t, err)
+		assert.Equal(t, cert.ID, res.ID)
+		assert.True(t, exist)
+	})
+}
+
 func TestCertificateManager_GetDefaultClientCert(t *testing.T) {
 	m, db, tenant := SetupCertificateManager(t)
 	r := sql.NewRepository(db)

--- a/internal/manager/export_test.go
+++ b/internal/manager/export_test.go
@@ -64,6 +64,13 @@ func (m *CertificateManager) GetDefaultHYOKClientCert(
 	return m.getDefaultHYOKClientCert(ctx)
 }
 
+func (m *CertificateManager) GetCertificateByPurpose(
+	ctx context.Context,
+	purpose model.CertificatePurpose,
+) (*model.Certificate, bool, error) {
+	return m.getCertificateByPurpose(ctx, purpose)
+}
+
 func (w *WorkflowManager) CreateWorkflowTransitionNotificationTask(
 	ctx context.Context,
 	workflow model.Workflow,


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.
Get Default Certificates were returning exists as default meaning they wouldn't be created if not exists
```

**Special notes for your reviewer**:
``` If no notes, remove the block.

```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.

```
