### PR TITLE
feat: enable event reconciler by default in values.yaml

### DIFF
--- a/charts/cmk/values.yaml
+++ b/charts/cmk/values.yaml
@@ -195,7 +195,8 @@ eventReconciler:
     #  - --graceful-shutdown-message="Graceful shutdown in %d seconds"
 
   # Enable the event-reconciler deployment.
-  deploy: false
+  # Should be enabled by default
+  deploy: true
 
   # task-cli service configuration
   service:


### PR DESCRIPTION
Missing from #104

This component should be enabled by default.