### PR TITLE
feat: Forward auth client_id

### DIFF
--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -284,7 +284,7 @@ func (o *TenantOperator) applyOIDC(ctx context.Context, tenantID string, cfg OID
 				Issuer:     cfg.Issuer,
 				JwksUri:    &cfg.JwksURI,
 				Audiences:  cfg.Audiences,
-				ClientId:   &cfg.ClientId,
+				ClientId:   &cfg.ClientID,
 				Properties: cfg.AdditionalProperties,
 			},
 		)

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -640,14 +640,14 @@ func TestHandleApplyAuth_SessionManagerResponse(t *testing.T) {
 				issuerURL := "http://issuer-url"
 				jwksURI := "http://jwks-uri"
 				audiences := "audience1"
-				clientId := "clientId1"
+				clientID := "clientID1"
 				auth := authgrpc.Auth{
 					TenantId: tenants[i],
 					Properties: map[string]string{
 						"issuer":    issuerURL,
 						"jwks_uri":  jwksURI,
 						"audiences": audiences,
-						"client_id": clientId,
+						"client_id": clientID,
 					},
 				}
 				data, err := proto.Marshal(&auth)
@@ -668,7 +668,7 @@ func TestHandleApplyAuth_SessionManagerResponse(t *testing.T) {
 					assert.Equal(t, issuerURL, req.GetIssuer())
 					assert.Equal(t, jwksURI, req.GetJwksUri())
 					assert.Equal(t, []string{audiences}, req.GetAudiences())
-					assert.Equal(t, clientId, req.GetClientId())
+					assert.Equal(t, clientID, req.GetClientId())
 
 					noOfCalls++
 
@@ -1261,13 +1261,13 @@ func TestExtractOIDCConfig(t *testing.T) {
 				"issuer":    "https://test.issuer.com",
 				"jwks_uri":  "https://test.jwks1.com",
 				"audiences": "audience1, audience2",
-				"client_id": "clientId",
+				"client_id": "clientID1",
 			},
 			expectedConfig: operator.OIDCConfig{
 				Issuer:               "https://test.issuer.com",
 				JwksURI:              "https://test.jwks1.com",
 				Audiences:            []string{"audience1", "audience2"},
-				ClientId:             "clientId",
+				ClientID:             "clientID1",
 				AdditionalProperties: map[string]string{},
 			},
 		},
@@ -1277,14 +1277,14 @@ func TestExtractOIDCConfig(t *testing.T) {
 				"issuer":        "https://test.issuer.com",
 				"jwks_uri":      "https://test.jwks1.com",
 				"audiences":     "audience1",
-				"client_id":     "clientId",
+				"client_id":     "clientID1",
 				"some-property": "some-property-value",
 			},
 			expectedConfig: operator.OIDCConfig{
 				Issuer:    "https://test.issuer.com",
 				JwksURI:   "https://test.jwks1.com",
 				Audiences: []string{"audience1"},
-				ClientId:  "clientId",
+				ClientID:  "clientID1",
 				AdditionalProperties: map[string]string{
 					"some-property": "some-property-value",
 				},
@@ -1299,7 +1299,7 @@ func TestExtractOIDCConfig(t *testing.T) {
 				Issuer:               "https://test.issuer.com",
 				JwksURI:              "",
 				Audiences:            []string{},
-				ClientId:             "",
+				ClientID:             "",
 				AdditionalProperties: map[string]string{},
 			},
 		},


### PR DESCRIPTION
# Forward Auth `client_id` in OIDC Mapping

### New Features

✨ Added support for forwarding an optional `client_id` field as part of the OIDC configuration when applying OIDC mappings. The `client_id` is parsed from the auth properties and passed through to the `ApplyOIDCMappingRequest`.

### Changes

* `internal/operator/operator.go`:
  - Added `ClientId` field to the `OIDCConfig` struct.
  - Added `keyClientId = "client_id"` constant for property key lookup.
  - Updated `extractOIDCConfig` to parse and populate `ClientId` from the properties map.
  - Updated the `ApplyOIDCMappingRequest` construction to include the `ClientId` field.

* `internal/operator/operator_test.go`:
  - Extended integration test to include `jwks_uri`, `audiences`, and `client_id` in the auth properties and added corresponding assertions on the `ApplyOIDCMappingRequest`.
  - Updated `TestExtractOIDCConfig` test cases to include `client_id` in input properties and expected `OIDCConfig`, covering valid properties, additional properties, and missing optional fields scenarios.
  - Fixed a test case that previously used `client-id` (hyphen) as an additional property key — it is now correctly recognized as `client_id` (underscore) and mapped to the `ClientId` field rather than treated as an additional property.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.18.5` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Event Trigger: `issue_comment.edited`
- Correlation ID: `c50c6d90-2112-11f1-974c-5dca289dc8ea`
</details>
