### PR TITLE
fix: get latest key version ID from DB for system events

### DIFF
--- a/internal/event-processor/reconciler_test.go
+++ b/internal/event-processor/reconciler_test.go
@@ -730,12 +730,19 @@ func TestVersionInfoPropagation(t *testing.T) {
 
 	testutils.CreateTestEntities(ctx, t, r, keyConfiguration, system, keyWithVersion, keyWithoutVersion)
 
-	// Setup plugin with version info for one key, not the other
-	instance.pluginOp.HandleKeyRecord(keyWithVersionID, testplugins.EnabledKeyStatus)
-	instance.pluginOp.SetKeyVersionInfo(keyWithVersionID, initialVersionID)
+	// Create key versions in DB for keyWithVersion only
+	kv := &model.KeyVersion{
+		ExternalID: uuid.NewString(),
+		KeyID:      keyWithVersion.ID,
+		Version:    1,
+		NativeID:   ptr.PointTo(initialVersionID),
+	}
+	err := r.Create(ctx, kv)
+	require.NoError(t, err)
 
+	// Setup plugin handlers (required for TransformCryptoAccessData)
+	instance.pluginOp.HandleKeyRecord(keyWithVersionID, testplugins.EnabledKeyStatus)
 	instance.pluginOp.HandleKeyRecord(keyWithoutVerID, testplugins.EnabledKeyStatus)
-	// No version info set for keyWithoutVersion
 
 	// Helper to resolve tasks and extract key access metadata
 	resolveAndExtractKeyAccessData := func(jobType string, keyID string) map[string]any {
@@ -773,7 +780,7 @@ func TestVersionInfoPropagation(t *testing.T) {
 			keyWithVersion.ID.String(),
 		)
 
-		// Assert version info from GetKey is present
+		// Assert version info from DB key version is present
 		assert.Equal(t, keyWithVersionID, keyAccessData["keyID"])
 		assert.Equal(t, initialVersionID, keyAccessData["versionIdentifier"])
 		assert.Equal(t, testRoleArn, keyAccessData["roleArn"])
@@ -792,8 +799,15 @@ func TestVersionInfoPropagation(t *testing.T) {
 	})
 
 	t.Run("should fetch fresh version info on every event creation", func(t *testing.T) {
-		// Update version info in plugin (simulating rotation)
-		instance.pluginOp.SetKeyVersionInfo(keyWithVersionID, updatedVersionID)
+		// Simulate rotation by adding a newer key version in the DB
+		kv := &model.KeyVersion{
+			ExternalID: uuid.NewString(),
+			KeyID:      keyWithVersion.ID,
+			Version:    2,
+			NativeID:   ptr.PointTo(updatedVersionID),
+		}
+		err := r.Create(ctx, kv)
+		require.NoError(t, err)
 
 		keyAccessData := resolveAndExtractKeyAccessData(
 			eventprocessor.JobTypeSystemSwitch.String(),

--- a/internal/event-processor/repo.go
+++ b/internal/event-processor/repo.go
@@ -2,12 +2,17 @@ package eventprocessor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/openkcm/cmk/internal/log"
 	"github.com/openkcm/cmk/internal/model"
 	"github.com/openkcm/cmk/internal/repo"
 	cmkcontext "github.com/openkcm/cmk/utils/context"
+)
+
+var (
+	ErrVersionHasNoNativeID = errors.New("latest key version has no native ID")
 )
 
 func getSystemByID(ctx context.Context, r repo.Repo, systemID string) (*model.System, error) {
@@ -76,6 +81,26 @@ func updateSystem(ctx context.Context, r repo.Repo, system *model.System) error 
 	}
 
 	return nil
+}
+
+func getNewestKeyVersionNativeID(ctx context.Context, r repo.Repo, keyID string) (string, error) {
+	var kv model.KeyVersion
+
+	ck := repo.NewCompositeKey().Where(fmt.Sprintf("%s_%s", repo.KeyField, repo.IDField), keyID)
+	query := repo.NewQuery().
+		Where(repo.NewCompositeKeyGroup(ck)).
+		Order(repo.OrderField{Field: repo.CreatedField, Direction: repo.Desc})
+
+	_, err := r.First(ctx, &kv, *query)
+	if err != nil {
+		return "", fmt.Errorf("failed to get newest key version for key %s: %w", keyID, err)
+	}
+
+	if kv.NativeID == nil {
+		return "", ErrVersionHasNoNativeID
+	}
+
+	return *kv.NativeID, nil
 }
 
 func updateKey(ctx context.Context, r repo.Repo, key *model.Key) error {

--- a/internal/event-processor/resolvers.go
+++ b/internal/event-processor/resolvers.go
@@ -3,6 +3,7 @@ package eventprocessor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/openkcm/cmk/internal/log"
 	"github.com/openkcm/cmk/internal/model"
 	cmkpluginregistry "github.com/openkcm/cmk/internal/pluginregistry"
-	"github.com/openkcm/cmk/internal/pluginregistry/service/api/common"
 	"github.com/openkcm/cmk/internal/pluginregistry/service/api/keymanagement"
 	"github.com/openkcm/cmk/internal/repo"
 	cmkcontext "github.com/openkcm/cmk/utils/context"
@@ -193,33 +193,29 @@ func (r *SystemTaskInfoResolver) selectKeyForTask(
 	return key, nil
 }
 
-// fetchAndPopulateVersionInfo fetches current key version info from the keystore provider
-// and populates it into the crypto access data for all regions
+// fetchAndPopulateVersionInfo fetches the newest key version from the DB
+// and populates its native ID into the crypto access data for all regions.
+// If no key version exists, the crypto access data is returned unchanged for backward compatibility.
 func (r *SystemTaskInfoResolver) fetchAndPopulateVersionInfo(
 	ctx context.Context,
-	client keymanagement.KeyManagement,
 	key model.Key,
 ) (map[string]map[string]any, error) {
-	// Fetch current version info from keystore provider
-	configValues := key.GetManagementAccessData()
-	freshKeyInfo, err := client.GetKey(ctx, &keymanagement.GetKeyRequest{
-		Parameters: keymanagement.RequestParameters{
-			Config: common.KeystoreConfig{Values: configValues},
-			KeyID:  *key.NativeID,
-		},
-	})
+	cryptoData := key.GetCryptoAccessData()
+
+	latestVersionID, err := getNewestKeyVersionNativeID(ctx, r.repo, key.ID.String())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get current key info: %w", err)
+		if errors.Is(err, repo.ErrNotFound) {
+			return cryptoData, nil
+		}
+		return nil, fmt.Errorf("failed to get latest key version native ID: %w", err)
 	}
 
-	// Merge fresh version info into crypto access data
-	cryptoData := key.GetCryptoAccessData()
-	if freshKeyInfo.LatestKeyVersionId != "" {
-		for region := range cryptoData {
-			if freshKeyInfo.LatestKeyVersionId != "" {
-				cryptoData[region]["versionIdentifier"] = freshKeyInfo.LatestKeyVersionId
-			}
-		}
+	if latestVersionID == "" {
+		return cryptoData, nil
+	}
+
+	for region := range cryptoData {
+		cryptoData[region]["versionIdentifier"] = latestVersionID
 	}
 
 	return cryptoData, nil
@@ -241,7 +237,7 @@ func (r *SystemTaskInfoResolver) getKeyAccessMetadata(
 	}
 
 	// Fetch and populate version info
-	cryptoData, err := r.fetchAndPopulateVersionInfo(ctx, client, key)
+	cryptoData, err := r.fetchAndPopulateVersionInfo(ctx, key)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Event reconciler has no access to managers and its logic to derive provider config, so calling plugin's GetKey - which requires authenticating to key provider to update key metadata - is not possible.
This PR simplifies it by getting the version ID from the DB.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal key version information retrieval to source from database records instead of plugin queries.

* **Tests**
  * Modified test setup to validate key version data originates from database persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->