### PR TITLE
fix: provided task config does not override Enabled flag if not specified

### DIFF
--- a/internal/async/scheduler_task_config.go
+++ b/internal/async/scheduler_task_config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hibiken/asynq"
 
 	"github.com/openkcm/cmk/internal/config"
+	"github.com/openkcm/cmk/utils/ptr"
 )
 
 // ScheduledTaskConfigProvider implements asynq PeriodicTaskConfigProvider interface.
@@ -19,17 +20,27 @@ func (p *ScheduledTaskConfigProvider) GetConfigs() ([]*asynq.PeriodicTaskConfig,
 	maps.Copy(tasks, config.PeriodicTasks)
 
 	for _, cfg := range p.Config.Scheduler.Tasks {
-		tasks[cfg.TaskType] = cfg
+		def := tasks[cfg.TaskType]
+		if cfg.Enabled != nil {
+			def.Enabled = cfg.Enabled
+		}
+		if cfg.Cronspec != "" {
+			def.Cronspec = cfg.Cronspec
+		}
+		if cfg.Retries != nil {
+			def.Retries = cfg.Retries
+		}
+		tasks[cfg.TaskType] = def
 	}
 
 	configs := make([]*asynq.PeriodicTaskConfig, 0)
 	for name, cfg := range tasks {
-		if !cfg.Enabled {
+		if cfg.Enabled != nil && !*cfg.Enabled {
 			continue
 		}
 		configs = append(configs, &asynq.PeriodicTaskConfig{
 			Cronspec: cfg.Cronspec,
-			Task:     asynq.NewTask(name, nil, asynq.MaxRetry(cfg.Retries)),
+			Task:     asynq.NewTask(name, nil, asynq.MaxRetry(ptr.GetIntOrDefault(cfg.Retries, 0))),
 		})
 	}
 

--- a/internal/async/scheduler_task_config_test.go
+++ b/internal/async/scheduler_task_config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openkcm/cmk/internal/async"
 	"github.com/openkcm/cmk/internal/config"
+	"github.com/openkcm/cmk/utils/ptr"
 )
 
 func TestGetConfigs(t *testing.T) {
@@ -16,14 +17,14 @@ func TestGetConfigs(t *testing.T) {
 
 		config.PeriodicTasks = map[string]config.Task{
 			"task1": {
-				Enabled:  true,
+				Enabled:  ptr.PointTo(true),
 				Cronspec: "*/1 * * * *",
-				Retries:  3,
+				Retries:  ptr.PointTo(3),
 			},
 			"task2": {
-				Enabled:  false,
+				Enabled:  ptr.PointTo(false),
 				Cronspec: "*/5 * * * *",
-				Retries:  0,
+				Retries:  ptr.PointTo(0),
 			},
 		}
 
@@ -44,14 +45,14 @@ func TestGetConfigs(t *testing.T) {
 
 		config.PeriodicTasks = map[string]config.Task{
 			"task1": {
-				Enabled:  true,
+				Enabled:  ptr.PointTo(true),
 				Cronspec: "1 * * * *",
-				Retries:  10,
+				Retries:  ptr.PointTo(10),
 			},
 			"task2": {
-				Enabled:  true,
+				Enabled:  ptr.PointTo(true),
 				Cronspec: "*/5 * * * *",
-				Retries:  0,
+				Retries:  ptr.PointTo(0),
 			},
 		}
 
@@ -61,15 +62,48 @@ func TestGetConfigs(t *testing.T) {
 					Tasks: []config.Task{
 						{
 							TaskType: "task1",
-							Enabled:  true,
+							Enabled:  ptr.PointTo(true),
 							Cronspec: "30 * * * *",
-							Retries:  1,
+							Retries:  ptr.PointTo(1),
 						},
 						{
 							TaskType: "task2",
-							Enabled:  false,
+							Enabled:  ptr.PointTo(false),
 							Cronspec: "30 * * * *",
-							Retries:  1,
+							Retries:  ptr.PointTo(1),
+						},
+					},
+				},
+			},
+		}
+
+		configs, err := p.GetConfigs()
+		assert.NoError(t, err)
+		assert.Len(t, configs, 1)
+		assert.Equal(t, "task1", configs[0].Task.Type())
+		assert.Equal(t, "30 * * * *", configs[0].Cronspec)
+	})
+
+	t.Run("Config without enabled field defaults enabled to true", func(t *testing.T) {
+		original := config.PeriodicTasks
+		defer func() { config.PeriodicTasks = original }()
+
+		config.PeriodicTasks = map[string]config.Task{
+			"task1": {
+				Enabled:  ptr.PointTo(true),
+				Cronspec: "1 * * * *",
+				Retries:  ptr.PointTo(3),
+			},
+		}
+
+		p := async.ScheduledTaskConfigProvider{
+			Config: &config.Config{
+				Scheduler: config.Scheduler{
+					Tasks: []config.Task{
+						{
+							// Enabled is nil — omitted from YAML, should keep default true
+							TaskType: "task1",
+							Cronspec: "30 * * * *",
 						},
 					},
 				},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,10 +165,10 @@ func (s *Scheduler) Validate() error {
 
 // Task holds a task config
 type Task struct {
-	Enabled  bool
+	Enabled  *bool
 	Cronspec string
 	TaskType string
-	Retries  int
+	Retries  *int
 }
 
 // Redis holds Redis client config

--- a/internal/config/tasks.go
+++ b/internal/config/tasks.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/openkcm/cmk/utils/ptr"
+
 const (
 	TypeSystemsTask        = "sys:refresh"
 	TypeCertificateTask    = "cert:rotate"
@@ -17,40 +19,40 @@ const defaultRetryCount = 3
 // PeriodicTasks defines the periodic tasks with their default configurations.
 var PeriodicTasks = map[string]Task{
 	TypeSystemsTask: {
-		Enabled:  true,
+		Enabled:  ptr.PointTo(true),
 		Cronspec: "0 * * * *", // Hourly
-		Retries:  defaultRetryCount,
+		Retries:  ptr.PointTo(defaultRetryCount),
 	},
 	TypeHYOKSync: {
-		Enabled:  true,
+		Enabled:  ptr.PointTo(true),
 		Cronspec: "0 * * * *", // Hourly
-		Retries:  defaultRetryCount,
+		Retries:  ptr.PointTo(defaultRetryCount),
 	},
 	TypeKeystorePool: {
-		Enabled:  true,
+		Enabled:  ptr.PointTo(true),
 		Cronspec: "0 * * * *", // Hourly
-		Retries:  defaultRetryCount,
+		Retries:  ptr.PointTo(defaultRetryCount),
 	},
 	TypeCertificateTask: {
-		Enabled:  true,
+		Enabled:  ptr.PointTo(true),
 		Cronspec: "0 0 * * *", // At 00:00 AM daily
-		Retries:  defaultRetryCount,
+		Retries:  ptr.PointTo(defaultRetryCount),
 	},
 	TypeWorkflowExpire: {
-		Enabled:  true,
+		Enabled:  ptr.PointTo(true),
 		Cronspec: "0 1 * * *", // At 01:00 AM daily
-		Retries:  defaultRetryCount,
+		Retries:  ptr.PointTo(defaultRetryCount),
 	},
 	TypeWorkflowCleanup: {
-		Enabled:  true,
+		Enabled:  ptr.PointTo(true),
 		Cronspec: "0 2 * * *", // At 02:00 AM daily
-		Retries:  defaultRetryCount,
+		Retries:  ptr.PointTo(defaultRetryCount),
 	},
 	// The TenantRefreshName was added to sync old tenants to have a tenant name
 	// This should be deleted on next release
 	TypeTenantRefreshName: {
-		Enabled:  true,
+		Enabled:  ptr.PointTo(true),
 		Cronspec: "0 3 * * *", // At 03:00 AM daily
-		Retries:  defaultRetryCount,
+		Retries:  ptr.PointTo(defaultRetryCount),
 	},
 }

--- a/test/integration/async_test/certrotation_test.go
+++ b/test/integration/async_test/certrotation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openkcm/cmk/internal/repo/sql"
 	"github.com/openkcm/cmk/internal/testutils"
 	integrationutils "github.com/openkcm/cmk/test/integration/integration_utils"
+	"github.com/openkcm/cmk/utils/ptr"
 )
 
 func TestCertRotation(t *testing.T) {
@@ -26,7 +27,7 @@ func TestCertRotation(t *testing.T) {
 		Tasks: []config.Task{{
 			Cronspec: "@every 1s",
 			TaskType: config.TypeCertificateTask,
-			Retries:  3,
+			Retries:  ptr.PointTo(3),
 		}},
 	})
 	SetupTestContainers(t, testConfig)

--- a/test/integration/async_test/hyoksync_test.go
+++ b/test/integration/async_test/hyoksync_test.go
@@ -27,7 +27,6 @@ func TestSchedulerHYOKSync(t *testing.T) {
 		Tasks: []config.Task{{
 			Cronspec: "@every 4s",
 			TaskType: config.TypeHYOKSync,
-			Retries:  0,
 		}},
 	})
 	SetupTestContainers(t, testConfig)

--- a/test/integration/async_test/keystorepool_test.go
+++ b/test/integration/async_test/keystorepool_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openkcm/cmk/internal/repo/sql"
 	"github.com/openkcm/cmk/internal/testutils"
 	integrationutils "github.com/openkcm/cmk/test/integration/integration_utils"
+	"github.com/openkcm/cmk/utils/ptr"
 )
 
 func TestKeystorePoolFilling(t *testing.T) {
@@ -26,7 +27,7 @@ func TestKeystorePoolFilling(t *testing.T) {
 		Tasks: []config.Task{{
 			Cronspec: "@every 1s",
 			TaskType: config.TypeKeystorePool,
-			Retries:  3,
+			Retries:  ptr.PointTo(3),
 		}},
 	})
 	SetupTestContainers(t, testConfig)

--- a/test/integration/async_test/systeminformation_test.go
+++ b/test/integration/async_test/systeminformation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openkcm/cmk/internal/repo/sql"
 	"github.com/openkcm/cmk/internal/testutils"
 	integrationutils "github.com/openkcm/cmk/test/integration/integration_utils"
+	"github.com/openkcm/cmk/utils/ptr"
 )
 
 var (
@@ -32,7 +33,7 @@ func TestSchedulerSystemRefresh(t *testing.T) {
 		Tasks: []config.Task{{
 			Cronspec: "@every 1s",
 			TaskType: config.TypeSystemsTask,
-			Retries:  3,
+			Retries:  ptr.PointTo(3),
 		}},
 	})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduler task overrides now properly merge with existing configurations instead of fully replacing them.

* **Refactor**
  * Improved task configuration flexibility by making optional configuration fields default to sensible values when not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->