### PR TITLE
Fix broken access for public endpoints

### DIFF
--- a/internal/authz/check.go
+++ b/internal/authz/check.go
@@ -16,6 +16,10 @@ func CheckAuthz[TResourceTypeName, TAction comparable](
 	resourceType TResourceTypeName,
 	action TAction,
 ) (bool, error) {
+	if cmkcontext.IsSystemUser(ctx) {
+		return true, nil
+	}
+
 	tenant, err := cmkcontext.ExtractTenantID(ctx)
 	if err != nil {
 		return false, errs.Wrap(ErrExtractTenantID, err)

--- a/internal/controllers/cmk/tenant_controller_test.go
+++ b/internal/controllers/cmk/tenant_controller_test.go
@@ -91,6 +91,9 @@ func TestGetTenants(t *testing.T) {
 		})
 
 		assert.Equal(t, http.StatusForbidden, w.Code)
+
+		response := testutils.GetJSONBody[cmkapi.ErrorMessage](t, w)
+		assert.Equal(t, "NO_TENANT_ACCESS", response.Error.Code)
 	})
 }
 

--- a/internal/controllers/cmk/userinfo_controller_test.go
+++ b/internal/controllers/cmk/userinfo_controller_test.go
@@ -65,6 +65,32 @@ func TestGetUserInfo(t *testing.T) {
 		assert.Contains(t, resp.Role, string(group.Role))
 	})
 
+	t.Run("Should 200 on get user info without group", func(t *testing.T) {
+		w := testutils.MakeHTTPRequest(t, sv, testutils.RequestOptions{
+			Method:   http.MethodGet,
+			Endpoint: "/userInfo",
+			Tenant:   tenant,
+			AdditionalContext: map[any]any{
+				constants.ClientData: &auth.ClientData{
+					Identifier: "user-123",
+					Email:      "bob@example.com",
+					GivenName:  "Bob",
+					FamilyName: "Builder",
+					Groups:     []string{"some-other-group"},
+				},
+			},
+		})
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		resp := testutils.GetJSONBody[cmkapi.GetUserInfo200JSONResponse](t, w)
+
+		assert.Equal(t, "user-123", resp.Identifier)
+		assert.Equal(t, "bob@example.com", resp.Email)
+		assert.Equal(t, "Bob", resp.GivenName)
+		assert.Equal(t, "Builder", resp.FamilyName)
+		assert.Contains(t, resp.Role, "")
+	})
+
 	t.Run("Should 500 on get user info with no client data", func(t *testing.T) {
 		group := testutils.NewGroup(func(_ *model.Group) {})
 		testutils.CreateTestEntities(ctx, t, r, group)

--- a/internal/manager/user.go
+++ b/internal/manager/user.go
@@ -222,7 +222,8 @@ func (u *user) GetUserInfo(ctx context.Context) (UserInfo, error) {
 		return UserInfo{}, err
 	}
 
-	role, err := u.GetRoleFromIAM(ctx, groups)
+	sysCtx := cmkcontext.InjectSystemUser(ctx)
+	role, err := u.GetRoleFromIAM(sysCtx, groups)
 	if err != nil {
 		return UserInfo{}, err
 	}
@@ -244,8 +245,9 @@ func (u *user) HasTenantAccess(ctx context.Context) (bool, error) {
 
 	ck := repo.NewCompositeKey().Where(repo.IAMIdField, iamIdentifiers)
 
+	sysCtx := cmkcontext.InjectSystemUser(ctx)
 	count, err := u.repo.Count(
-		ctx, &model.Group{},
+		sysCtx, &model.Group{},
 		*repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)).SetLimit(0),
 	)
 	if err != nil {

--- a/utils/context/context.go
+++ b/utils/context/context.go
@@ -180,11 +180,12 @@ func IsSystemUser(ctx context.Context) bool {
 func InjectSystemUser(ctx context.Context) context.Context {
 	clientData, err := ExtractClientData(ctx)
 	// Use zero values and system user
-	if err != nil {
+	if err != nil || clientData == nil {
 		clientData = &auth.ClientData{}
 	}
 
-	clientData.Identifier = uuid.Max.String()
+	clientDataCopy := *clientData
+	clientDataCopy.Identifier = uuid.Max.String()
 
-	return context.WithValue(ctx, constants.ClientData, clientData)
+	return context.WithValue(ctx, constants.ClientData, &clientDataCopy)
 }


### PR DESCRIPTION
fix: broken access for public endpoints

**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.
Addition of DB level authz broke access for public endpoints. This PR addresses.
Fix is temporary and comes at cost of potentially missing information from application access logs.
However, this will be addressed fully in later PR.
```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.
NONE
```
