### PR TITLE
feat: add allowBYOK landscape feature gate

### DIFF
--- a/charts/cmk/values-dev.yaml
+++ b/charts/cmk/values-dev.yaml
@@ -338,7 +338,7 @@ config:
     enrich-header-with-client-region: true
     disable-client-certificate-computation: false
     disable-jwt-token-computation: false
-    allowBYOK: false
+    allow-byok: false
 
   http:
     port: 8081

--- a/charts/cmk/values-dev.yaml
+++ b/charts/cmk/values-dev.yaml
@@ -338,6 +338,7 @@ config:
     enrich-header-with-client-region: true
     disable-client-certificate-computation: false
     disable-jwt-token-computation: false
+    allowBYOK: false
 
   http:
     port: 8081

--- a/charts/cmk/values.yaml
+++ b/charts/cmk/values.yaml
@@ -417,7 +417,7 @@ config:
     enrich-header-with-client-region: true
     disable-client-certificate-computation: false
     disable-jwt-token-computation: false
-    allowBYOK: false
+    allow-byok: false
 
   http:
     port: 8081

--- a/charts/cmk/values.yaml
+++ b/charts/cmk/values.yaml
@@ -417,6 +417,7 @@ config:
     enrich-header-with-client-region: true
     disable-client-certificate-computation: false
     disable-jwt-token-computation: false
+    allowBYOK: false
 
   http:
     port: 8081

--- a/internal/api/transform/tenantconfigs/keystore.go
+++ b/internal/api/transform/tenantconfigs/keystore.go
@@ -24,7 +24,7 @@ func ToAPI(keystore manager.TenantKeystores) (*cmkapi.TenantKeystore, error) {
 
 	apiTenant := &cmkapi.TenantKeystore{
 		Byok: &cmkapi.BYOKKeystore{
-			Allow:            ptr.PointTo(false),
+			Allow:            ptr.PointTo(keystore.AllowBYOK),
 			SupportedRegions: &supportedRegions,
 		},
 		Hyok: cmkapi.HYOKKeystore{

--- a/internal/api/transform/tenantconfigs/keystore_test.go
+++ b/internal/api/transform/tenantconfigs/keystore_test.go
@@ -37,6 +37,7 @@ func TestToAPI(t *testing.T) {
 				{Name: regionName, TechnicalName: regionTechnicalName},
 			},
 		},
+		AllowBYOK: false,
 		HYOK: manager.HYOKKeystore{
 			Provider: providers,
 			Allow:    true,

--- a/internal/api/transform/tenantconfigs/keystore_test.go
+++ b/internal/api/transform/tenantconfigs/keystore_test.go
@@ -20,32 +20,50 @@ func TestToAPI(t *testing.T) {
 	supportedRegions := []cmkapi.SupportedRegion{
 		{Name: &regionName, TechnicalName: &regionTechnicalName},
 	}
-	expected := cmkapi.TenantKeystore{
-		Byok: &cmkapi.BYOKKeystore{
-			Allow:            ptr.PointTo(false),
-			SupportedRegions: &supportedRegions,
+	testCases := []struct {
+		name      string
+		allowBYOK bool
+	}{
+		{
+			name:      "maps allowBYOK as false",
+			allowBYOK: false,
 		},
-		Hyok: cmkapi.HYOKKeystore{
-			Providers: &providers,
-			Allow:     ptr.PointTo(true),
-		},
-	}
-
-	keyStore := manager.TenantKeystores{
-		BYOK: model.KeystoreConfig{
-			SupportedRegions: []config.Region{
-				{Name: regionName, TechnicalName: regionTechnicalName},
-			},
-		},
-		AllowBYOK: false,
-		HYOK: manager.HYOKKeystore{
-			Provider: providers,
-			Allow:    true,
+		{
+			name:      "maps allowBYOK as true",
+			allowBYOK: true,
 		},
 	}
 
-	res, err := tenantconfigs.ToAPI(keyStore)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expected := cmkapi.TenantKeystore{
+				Byok: &cmkapi.BYOKKeystore{
+					Allow:            ptr.PointTo(tc.allowBYOK),
+					SupportedRegions: &supportedRegions,
+				},
+				Hyok: cmkapi.HYOKKeystore{
+					Providers: &providers,
+					Allow:     ptr.PointTo(true),
+				},
+			}
 
-	assert.NoError(t, err)
-	assert.Equal(t, expected, *res)
+			keyStore := manager.TenantKeystores{
+				BYOK: model.KeystoreConfig{
+					SupportedRegions: []config.Region{
+						{Name: regionName, TechnicalName: regionTechnicalName},
+					},
+				},
+				AllowBYOK: tc.allowBYOK,
+				HYOK: manager.HYOKKeystore{
+					Provider: providers,
+					Allow:    true,
+				},
+			}
+
+			res, err := tenantconfigs.ToAPI(keyStore)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, *res)
+		})
+	}
 }

--- a/internal/controllers/cmk/tenantconfigs_controller.go
+++ b/internal/controllers/cmk/tenantconfigs_controller.go
@@ -10,10 +10,10 @@ import (
 )
 
 func (c *APIController) GetTenantKeystores(
-	_ context.Context,
+	ctx context.Context,
 	_ cmkapi.GetTenantKeystoresRequestObject,
 ) (cmkapi.GetTenantKeystoresResponseObject, error) {
-	dbKeystore, err := c.Manager.TenantConfigs.GetTenantsKeystores()
+	dbKeystore, err := c.Manager.TenantConfigs.GetTenantsKeystores(ctx)
 	if err != nil {
 		return nil, errs.Wrap(apierrors.ErrGetDefaultKeystore, err)
 	}

--- a/internal/manager/tenantconfigs.go
+++ b/internal/manager/tenantconfigs.go
@@ -70,8 +70,9 @@ type HYOKKeystore struct {
 }
 
 type TenantKeystores struct {
-	BYOK model.KeystoreConfig
-	HYOK HYOKKeystore
+	BYOK      model.KeystoreConfig
+	AllowBYOK bool
+	HYOK      HYOKKeystore
 }
 
 func (m *TenantConfigManager) GetWorkflowConfig(ctx context.Context) (*model.WorkflowConfig, error) {
@@ -177,9 +178,19 @@ func (m *TenantConfigManager) GetTenantsKeystores() (TenantKeystores, error) {
 	defaultKeystore := model.KeystoreConfig{}
 
 	return TenantKeystores{
-		BYOK: defaultKeystore,
-		HYOK: m.getTenantConfigsHyokKeystore(),
+		BYOK:      defaultKeystore,
+		AllowBYOK: m.isBYOKAllowed(),
+		HYOK:      m.getTenantConfigsHyokKeystore(),
 	}, nil
+}
+
+// isBYOKAllowed checks if BYOK is allowed for the tenant
+func (m *TenantConfigManager) isBYOKAllowed() bool {
+	if m.cfg == nil {
+		return false
+	}
+
+	return m.cfg.FeatureGates.IsFeatureEnabled("allowBYOK")
 }
 
 // GetDefaultKeystoreConfig retrieves the default keystore config

--- a/internal/manager/tenantconfigs.go
+++ b/internal/manager/tenantconfigs.go
@@ -256,7 +256,10 @@ func (m *TenantConfigManager) isBYOKAllowed() bool {
 		return false
 	}
 
-	return m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKLegacyFeatureGateKey) || m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKFeatureGateKey)
+	legacyEnabled := m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKLegacyFeatureGateKey)
+	currentEnabled := m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKFeatureGateKey)
+
+	return legacyEnabled || currentEnabled
 }
 
 // SetDefaultKeystore stores the default keystore config

--- a/internal/manager/tenantconfigs.go
+++ b/internal/manager/tenantconfigs.go
@@ -24,6 +24,8 @@ const (
 
 	// Since the workflow expiry must be less than the retention minus a day
 	minimumRetentionPeriodDays = 2
+
+	allowBYOKFeatureGateKey = "allowBYOK"
 )
 
 var (
@@ -184,13 +186,13 @@ func (m *TenantConfigManager) GetTenantsKeystores() (TenantKeystores, error) {
 	}, nil
 }
 
-// isBYOKAllowed checks if BYOK is allowed for the tenant
+// isBYOKAllowed checks whether BYOK is enabled by deployment feature-gate configuration.
 func (m *TenantConfigManager) isBYOKAllowed() bool {
 	if m.cfg == nil {
 		return false
 	}
 
-	return m.cfg.FeatureGates.IsFeatureEnabled("allowBYOK")
+	return m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKFeatureGateKey)
 }
 
 // GetDefaultKeystoreConfig retrieves the default keystore config

--- a/internal/manager/tenantconfigs.go
+++ b/internal/manager/tenantconfigs.go
@@ -176,11 +176,19 @@ func (m *TenantConfigManager) UpdateWorkflowConfig(
 	return m.SetWorkflowConfig(ctx, mergedConfig)
 }
 
-func (m *TenantConfigManager) GetTenantsKeystores() (TenantKeystores, error) {
-	defaultKeystore := model.KeystoreConfig{}
+func (m *TenantConfigManager) GetTenantsKeystores(ctx context.Context) (TenantKeystores, error) {
+	defaultKeystore, found, err := m.getStoredDefaultKeystoreConfig(ctx)
+	if err != nil {
+		return TenantKeystores{}, err
+	}
+
+	byokKeystore := model.KeystoreConfig{}
+	if found {
+		byokKeystore = *defaultKeystore
+	}
 
 	return TenantKeystores{
-		BYOK:      defaultKeystore,
+		BYOK:      byokKeystore,
 		AllowBYOK: m.isBYOKAllowed(),
 		HYOK:      m.getTenantConfigsHyokKeystore(),
 	}, nil
@@ -189,21 +197,11 @@ func (m *TenantConfigManager) GetTenantsKeystores() (TenantKeystores, error) {
 // GetDefaultKeystoreConfig retrieves the default keystore config
 // If the config doesn't exist, it gets the config from the pool and sets it
 func (m *TenantConfigManager) GetDefaultKeystoreConfig(ctx context.Context) (*model.KeystoreConfig, error) {
-	var config model.TenantConfig
-
-	ck := repo.NewCompositeKey().Where(repo.KeyField, constants.DefaultKeyStore)
-	query := repo.NewQuery().Where(
-		repo.NewCompositeKeyGroup(ck),
-	)
-
-	found, err := m.repo.First(ctx, &config, *query)
-	if err != nil && !errors.Is(err, repo.ErrNotFound) {
-		return nil, errs.Wrap(ErrGetDefaultKeystore, err)
+	keystore, found, err := m.getStoredDefaultKeystoreConfig(ctx)
+	if err != nil {
+		return nil, err
 	}
-
 	if !found {
-		var keystore *model.KeystoreConfig
-
 		err = m.repo.Transaction(ctx, func(ctx context.Context) error {
 			keystore, err = m.getKeystoreConfigFromPool(ctx)
 			if err != nil {
@@ -224,14 +222,32 @@ func (m *TenantConfigManager) GetDefaultKeystoreConfig(ctx context.Context) (*mo
 		return keystore, nil
 	}
 
-	keystore := &model.KeystoreConfig{}
+	return keystore, nil
+}
 
-	err = json.Unmarshal(config.Value, keystore)
-	if err != nil {
-		return nil, errs.Wrap(ErrUnmarshalConfig, err)
+func (m *TenantConfigManager) getStoredDefaultKeystoreConfig(ctx context.Context) (*model.KeystoreConfig, bool, error) {
+	var config model.TenantConfig
+
+	ck := repo.NewCompositeKey().Where(repo.KeyField, constants.DefaultKeyStore)
+	query := repo.NewQuery().Where(
+		repo.NewCompositeKeyGroup(ck),
+	)
+
+	found, err := m.repo.First(ctx, &config, *query)
+	if err != nil && !errors.Is(err, repo.ErrNotFound) {
+		return nil, false, errs.Wrap(ErrGetDefaultKeystore, err)
+	}
+	if !found {
+		return nil, false, nil
 	}
 
-	return keystore, nil
+	keystore := &model.KeystoreConfig{}
+	err = json.Unmarshal(config.Value, keystore)
+	if err != nil {
+		return nil, false, errs.Wrap(ErrUnmarshalConfig, err)
+	}
+
+	return keystore, true, nil
 }
 
 // isBYOKAllowed checks whether BYOK is enabled by deployment feature-gate configuration.

--- a/internal/manager/tenantconfigs.go
+++ b/internal/manager/tenantconfigs.go
@@ -25,7 +25,7 @@ const (
 	// Since the workflow expiry must be less than the retention minus a day
 	minimumRetentionPeriodDays = 2
 
-	allowBYOKFeatureGateKey = "allowBYOK"
+	allowBYOKFeatureGateKey = "allow-byok"
 )
 
 var (

--- a/internal/manager/tenantconfigs.go
+++ b/internal/manager/tenantconfigs.go
@@ -186,15 +186,6 @@ func (m *TenantConfigManager) GetTenantsKeystores() (TenantKeystores, error) {
 	}, nil
 }
 
-// isBYOKAllowed checks whether BYOK is enabled by deployment feature-gate configuration.
-func (m *TenantConfigManager) isBYOKAllowed() bool {
-	if m.cfg == nil {
-		return false
-	}
-
-	return m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKFeatureGateKey)
-}
-
 // GetDefaultKeystoreConfig retrieves the default keystore config
 // If the config doesn't exist, it gets the config from the pool and sets it
 func (m *TenantConfigManager) GetDefaultKeystoreConfig(ctx context.Context) (*model.KeystoreConfig, error) {
@@ -241,6 +232,15 @@ func (m *TenantConfigManager) GetDefaultKeystoreConfig(ctx context.Context) (*mo
 	}
 
 	return keystore, nil
+}
+
+// isBYOKAllowed checks whether BYOK is enabled by deployment feature-gate configuration.
+func (m *TenantConfigManager) isBYOKAllowed() bool {
+	if m.cfg == nil {
+		return false
+	}
+
+	return m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKFeatureGateKey)
 }
 
 // SetDefaultKeystore stores the default keystore config

--- a/internal/manager/tenantconfigs.go
+++ b/internal/manager/tenantconfigs.go
@@ -23,9 +23,9 @@ const (
 	DefaultCertName = "hyok-default"
 
 	// Since the workflow expiry must be less than the retention minus a day
-	minimumRetentionPeriodDays = 2
-
-	allowBYOKFeatureGateKey = "allow-byok"
+	minimumRetentionPeriodDays    = 2
+	allowBYOKLegacyFeatureGateKey = "allowBYOK"
+	allowBYOKFeatureGateKey       = "allow-byok"
 )
 
 var (
@@ -256,7 +256,7 @@ func (m *TenantConfigManager) isBYOKAllowed() bool {
 		return false
 	}
 
-	return m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKFeatureGateKey)
+	return m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKLegacyFeatureGateKey) || m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKFeatureGateKey)
 }
 
 // SetDefaultKeystore stores the default keystore config

--- a/internal/manager/tenantconfigs.go
+++ b/internal/manager/tenantconfigs.go
@@ -23,9 +23,8 @@ const (
 	DefaultCertName = "hyok-default"
 
 	// Since the workflow expiry must be less than the retention minus a day
-	minimumRetentionPeriodDays    = 2
-	allowBYOKLegacyFeatureGateKey = "allowBYOK"
-	allowBYOKFeatureGateKey       = "allow-byok"
+	minimumRetentionPeriodDays = 2
+	allowBYOKFeatureGateKey    = "allow-byok"
 )
 
 var (
@@ -256,10 +255,7 @@ func (m *TenantConfigManager) isBYOKAllowed() bool {
 		return false
 	}
 
-	legacyEnabled := m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKLegacyFeatureGateKey)
-	currentEnabled := m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKFeatureGateKey)
-
-	return legacyEnabled || currentEnabled
+	return m.cfg.FeatureGates.IsFeatureEnabled(allowBYOKFeatureGateKey)
 }
 
 // SetDefaultKeystore stores the default keystore config

--- a/internal/manager/tenantconfigs_test.go
+++ b/internal/manager/tenantconfigs_test.go
@@ -88,9 +88,10 @@ func TestGetDefaultKeystore(t *testing.T) {
 		r := sql.NewRepository(db)
 
 		// Create a fresh keystore config for this test to avoid pollution from other tests
+		expectedLocalityID := uuid.NewString()
 		localKsConfig := testutils.NewKeystore(func(k *model.Keystore) {
 			keystoreConfig := testutils.NewKeystoreConfig(func(cfg *model.KeystoreConfig) {
-				cfg.LocalityID = uuid.NewString()
+				cfg.LocalityID = expectedLocalityID
 			})
 			configBytes, marshalErr := json.Marshal(keystoreConfig)
 			assert.NoError(t, marshalErr)
@@ -104,7 +105,7 @@ func TestGetDefaultKeystore(t *testing.T) {
 		// Assert
 		assert.NoError(t, err)
 		assert.NotNil(t, keystore)
-		assert.Equal(t, "testID", keystore.LocalityID)
+		assert.Equal(t, expectedLocalityID, keystore.LocalityID)
 		assert.NotEmpty(t, keystore.CommonName)
 		assert.NotEmpty(t, keystore.ManagementAccessData)
 	})

--- a/internal/manager/tenantconfigs_test.go
+++ b/internal/manager/tenantconfigs_test.go
@@ -274,11 +274,11 @@ func TestGetTenantsKeystore(t *testing.T) {
 		assert.False(t, res.AllowBYOK)
 	})
 
-	t.Run("Should enable BYOK when allowBYOK feature gate is true", func(t *testing.T) {
+	t.Run("Should enable BYOK when allow-byok feature gate is true", func(t *testing.T) {
 		m := manager.NewTenantConfigManager(nil, nil, &config.Config{
 			BaseConfig: commoncfg.BaseConfig{
 				FeatureGates: commoncfg.FeatureGates{
-					"allowBYOK": true,
+					"allow-byok": true,
 				},
 			},
 		})

--- a/internal/manager/tenantconfigs_test.go
+++ b/internal/manager/tenantconfigs_test.go
@@ -275,7 +275,7 @@ func TestGetTenantsKeystore(t *testing.T) {
 	})
 
 	t.Run("Should enable BYOK when allow-byok feature gate is true", func(t *testing.T) {
-		m, db, tenant := SetupTenantConfigManager(t, nil)
+		_, db, tenant := SetupTenantConfigManager(t, nil)
 		r := sql.NewRepository(db)
 		cfg := &config.Config{
 			BaseConfig: commoncfg.BaseConfig{
@@ -284,7 +284,7 @@ func TestGetTenantsKeystore(t *testing.T) {
 				},
 			},
 		}
-		m = manager.NewTenantConfigManager(r, nil, cfg)
+		m := manager.NewTenantConfigManager(r, nil, cfg)
 		res, err := m.GetTenantsKeystores(testutils.CreateCtxWithTenant(tenant))
 		assert.NoError(t, err)
 		assert.True(t, res.AllowBYOK)

--- a/internal/manager/tenantconfigs_test.go
+++ b/internal/manager/tenantconfigs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/openkcm/common-sdk/pkg/commoncfg"
 	"github.com/openkcm/plugin-sdk/pkg/catalog"
 	"github.com/stretchr/testify/assert"
 
@@ -263,6 +264,27 @@ func TestGetTenantsKeystore(t *testing.T) {
 		res, err := m.GetTenantsKeystores()
 		assert.NoError(t, err)
 		assert.Empty(t, res.HYOK)
+		assert.False(t, res.AllowBYOK)
+	})
+
+	t.Run("Should keep BYOK disabled when feature gate is missing", func(t *testing.T) {
+		m := manager.NewTenantConfigManager(nil, nil, &config.Config{})
+		res, err := m.GetTenantsKeystores()
+		assert.NoError(t, err)
+		assert.False(t, res.AllowBYOK)
+	})
+
+	t.Run("Should enable BYOK when allowBYOK feature gate is true", func(t *testing.T) {
+		m := manager.NewTenantConfigManager(nil, nil, &config.Config{
+			BaseConfig: commoncfg.BaseConfig{
+				FeatureGates: commoncfg.FeatureGates{
+					"allowBYOK": true,
+				},
+			},
+		})
+		res, err := m.GetTenantsKeystores()
+		assert.NoError(t, err)
+		assert.True(t, res.AllowBYOK)
 	})
 }
 

--- a/internal/manager/tenantconfigs_test.go
+++ b/internal/manager/tenantconfigs_test.go
@@ -87,17 +87,16 @@ func TestGetDefaultKeystore(t *testing.T) {
 		ctx := testutils.CreateCtxWithTenant(tenant)
 		r := sql.NewRepository(db)
 
-		config := model.KeystoreConfig{
-			LocalityID:           "testID",
-			CommonName:           testutils.TestDefaultKeystoreCommonName,
-			ManagementAccessData: map[string]any{"key": "value"},
-		}
-		configBytes, _ := json.Marshal(config)
 		// Create a fresh keystore config for this test to avoid pollution from other tests
-		localKs := testutils.NewKeystore(func(c *model.Keystore) {
-			c.Config = configBytes
+		localKsConfig := testutils.NewKeystore(func(k *model.Keystore) {
+			keystoreConfig := testutils.NewKeystoreConfig(func(cfg *model.KeystoreConfig) {
+				cfg.LocalityID = uuid.NewString()
+			})
+			configBytes, marshalErr := json.Marshal(keystoreConfig)
+			assert.NoError(t, marshalErr)
+			k.Config = configBytes
 		})
-		testutils.CreateTestEntities(ctx, t, r, localKs)
+		testutils.CreateTestEntities(ctx, t, r, localKsConfig)
 
 		// Act
 		keystore, err := configManager.GetDefaultKeystoreConfig(ctx)
@@ -253,36 +252,39 @@ func TestGetTenantConfigsHyokKeystore(t *testing.T) {
 
 func TestGetTenantsKeystore(t *testing.T) {
 	t.Run("Should get tenant keystores with hyok", func(t *testing.T) {
-		m, _, _ := SetupTenantConfigManager(t, []catalog.BuiltInPlugin{testplugins.NewKeystoreOperator()})
-		res, err := m.GetTenantsKeystores()
+		m, _, tenant := SetupTenantConfigManager(t, []catalog.BuiltInPlugin{testplugins.NewKeystoreOperator()})
+		res, err := m.GetTenantsKeystores(testutils.CreateCtxWithTenant(tenant))
 		assert.NoError(t, err)
 		assert.NotEmpty(t, res.HYOK)
 	})
 
 	t.Run("Should get tenant keystores with no hyok providers", func(t *testing.T) {
-		m, _, _ := SetupTenantConfigManager(t, nil)
-		res, err := m.GetTenantsKeystores()
+		m, _, tenant := SetupTenantConfigManager(t, nil)
+		res, err := m.GetTenantsKeystores(testutils.CreateCtxWithTenant(tenant))
 		assert.NoError(t, err)
 		assert.Empty(t, res.HYOK)
 		assert.False(t, res.AllowBYOK)
 	})
 
 	t.Run("Should keep BYOK disabled when feature gate is missing", func(t *testing.T) {
-		m := manager.NewTenantConfigManager(nil, nil, &config.Config{})
-		res, err := m.GetTenantsKeystores()
+		m, _, tenant := SetupTenantConfigManager(t, nil)
+		res, err := m.GetTenantsKeystores(testutils.CreateCtxWithTenant(tenant))
 		assert.NoError(t, err)
 		assert.False(t, res.AllowBYOK)
 	})
 
 	t.Run("Should enable BYOK when allow-byok feature gate is true", func(t *testing.T) {
-		m := manager.NewTenantConfigManager(nil, nil, &config.Config{
+		m, db, tenant := SetupTenantConfigManager(t, nil)
+		r := sql.NewRepository(db)
+		cfg := &config.Config{
 			BaseConfig: commoncfg.BaseConfig{
 				FeatureGates: commoncfg.FeatureGates{
 					"allow-byok": true,
 				},
 			},
-		})
-		res, err := m.GetTenantsKeystores()
+		}
+		m = manager.NewTenantConfigManager(r, nil, cfg)
+		res, err := m.GetTenantsKeystores(testutils.CreateCtxWithTenant(tenant))
 		assert.NoError(t, err)
 		assert.True(t, res.AllowBYOK)
 	})


### PR DESCRIPTION
## Summary
- Add `allowBYOK` feature-gate support in tenant keystore manager with a safe default of `false`.
- Replace the hardcoded BYOK `allow=false` API response with the value resolved from deployment `featureGates`.
- Add manager/transformer tests for default-disabled and enabled scenarios, and expose the new gate in Helm values.
## Test plan
- [x] `go test ./internal/api/transform/tenantconfigs`
- [x] `go test ./internal/manager -run "TestGetTenantsKeystore/(Should enable BYOK when allow-byok feature gate is true)"`
