### PR TITLE
fix: import postgres driver for tracing

### DIFF
--- a/internal/db/tracing.go
+++ b/internal/db/tracing.go
@@ -8,6 +8,8 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
+	_ "github.com/lib/pq" // Import PostgreSQL driver
+
 	"github.com/openkcm/cmk/internal/constants"
 	"github.com/openkcm/cmk/internal/errs"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Seeing error
```
{"time":"Thu Apr 16 15:06:22 +0000 2026","level":"ERROR","msg":"Failed to start the application","serviceName":"db-migrator","environment":"local","err":"error starting db connection: error wrapping dialector with tracing: sql: unknown driver \"postgres\" (forgotten import?)"}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Ensured PostgreSQL driver initialization for proper database connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->