### PR TITLE
chore: remove active plugins from helm charts as no longer supported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ GIT_CREDENTIAL_HELPER=$(shell git config credential.helper)
 GIT_USERNAME=$(shell echo "" | git credential-$(GIT_CREDENTIAL_HELPER) get | awk -F= '$$1=="username"{print $$2}')
 GIT_PASSWORD=$(shell echo "" | git credential-$(GIT_CREDENTIAL_HELPER) get | awk -F= '$$1=="password"{print $$2}')
 SIS_PLUGIN ?= "uli"
-ACTIVE_PLUGINS := "{hyok,default_keystore,keystore_provider,$(SIS_PLUGIN),cert_issuer,identity_management,notification}"
 
 # get git values
 squash: HEAD := $(shell git rev-parse HEAD)
@@ -375,7 +374,6 @@ k3d-apply-helm-chart:
 	@echo "Applying Helm chart."
 	helm upgrade --install $(CHART_NAME) $(CHART_DIR) --namespace $(APPLY_NAMESPACE) \
 		--set volumePath=$(PATH_TO_INIT_VOLUME) \
-		--set config.activePlugins=$(ACTIVE_PLUGINS) \
 		-f $(VALUE_DIR)/values-dev.yaml
 
 k3d-apply-cmk-helm-chart:

--- a/charts/cmk/templates/_helpers.tpl
+++ b/charts/cmk/templates/_helpers.tpl
@@ -229,21 +229,8 @@ Util function for generating the image URL based on the provided options.
 {{- end }}
 
 {{/*
-Active plugins
+Plugins
 */}}
 {{- define "cmk.plugins" -}}
-{{- $ := . }}
-{{- $plugins := list -}}
-{{- range .plugins -}}
-{{- $plugin := . -}}
-{{- range .tags -}}
-{{- if has . $.activePlugins -}}
-
-{{- $plugins = append $plugins $plugin -}}
-{{- break -}}
-
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- toYaml $plugins -}}
+{{- toYaml .plugins -}}
 {{- end -}}

--- a/charts/cmk/values-dev.yaml
+++ b/charts/cmk/values-dev.yaml
@@ -727,8 +727,6 @@ config:
             headerFields:
               x-app_tid: app_tid
               x-client_id: client_id
-  activePlugins:
-    - identity_management
   provisioning:
     initKeystoreConfig:
       enabled: true

--- a/charts/cmk/values.yaml
+++ b/charts/cmk/values.yaml
@@ -793,13 +793,6 @@ config:
   #        key1: value1
   #        key2: value2
 
-  # Active plugins are controlled through Makefile.
-  # See k3d-apply-helm-chart target definition and ACTIVE_PLUGINS variable in the Makefile.
-  activePlugins:
-  # - plugin1
-  # - plugin2
-  # - plugin3
-
   # Event configuration
   eventProcessor:
     #secretRef:


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->
Update helm helper and values to no longer support activePlugins as this is no longer used, and the new plugins architecture doesn't support it 