### PR TITLE
fix: return supportedRegions before keystore is retrieved from pool

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -368,8 +368,9 @@ type Region struct {
 }
 
 type KeystorePool struct {
-	Size     int           `yaml:"size" default:"5"`
-	Interval time.Duration `yaml:"interval" default:"1h"`
+	Size             int                 `yaml:"size" default:"5"`
+	Interval         time.Duration       `yaml:"interval" default:"1h"`
+	SupportedRegions commoncfg.SourceRef `yaml:"supportedRegions" json:"supportedRegions"`
 }
 
 type Landscape struct {

--- a/internal/manager/tenantconfigs.go
+++ b/internal/manager/tenantconfigs.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/openkcm/common-sdk/pkg/commoncfg"
+
 	tenantpb "github.com/openkcm/api-sdk/proto/kms/api/cmk/registry/tenant/v1"
 
 	"github.com/openkcm/cmk/internal/api/cmkapi"
@@ -191,13 +193,29 @@ func (m *TenantConfigManager) GetTenantsKeystores(ctx context.Context) (TenantKe
 		return TenantKeystores{}, err
 	}
 
-	byokKeystore := model.KeystoreConfig{}
+	var supportedRegions []config.Region
+	byokKeystore := &model.KeystoreConfig{}
 	if found {
-		byokKeystore = *defaultKeystore
+		byokKeystore = defaultKeystore
+	} else if m.isBYOKAllowed() && m.cfg.KeystorePool.SupportedRegions.Source != "" {
+		// Initialize supportedRegions to an empty slice.
+		// If BYOK is allowed, populate it with the configured supported regions.
+		// This ensures that supportedRegions is always defined even if keystore has not been retrieved from pool.
+		ref, err := commoncfg.LoadValueFromSourceRef(m.cfg.KeystorePool.SupportedRegions)
+		if err != nil {
+			return TenantKeystores{}, err
+		}
+
+		err = json.Unmarshal(ref, &supportedRegions)
+		if err != nil {
+			return TenantKeystores{}, err
+		}
+
+		byokKeystore.SupportedRegions = supportedRegions
 	}
 
 	return TenantKeystores{
-		BYOK:      byokKeystore,
+		BYOK:      *byokKeystore,
 		AllowBYOK: m.isBYOKAllowed(),
 		HYOK:      m.getTenantConfigsHyokKeystore(),
 	}, nil

--- a/internal/manager/tenantconfigs_test.go
+++ b/internal/manager/tenantconfigs_test.go
@@ -279,6 +279,77 @@ func TestGetTenantsKeystore(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, res.AllowBYOK)
 	})
+
+	t.Run("BYOK allowed, no stored keystore: regions from config", func(t *testing.T) {
+		_, db, tenant := SetupTenantConfigManager(t)
+		r := sql.NewRepository(db)
+
+		regionsJSON, err := json.Marshal(testutils.SupportedRegions)
+		assert.NoError(t, err)
+
+		cfg := &config.Config{
+			BaseConfig: commoncfg.BaseConfig{
+				FeatureGates: commoncfg.FeatureGates{"allow-byok": true},
+			},
+			KeystorePool: config.KeystorePool{
+				SupportedRegions: commoncfg.SourceRef{
+					Source: commoncfg.EmbeddedSourceValue,
+					Value:  string(regionsJSON),
+				},
+			},
+		}
+		m := manager.NewTenantConfigManager(r, nil, cfg)
+		res, err := m.GetTenantsKeystores(testutils.CreateCtxWithTenant(tenant))
+		assert.NoError(t, err)
+		assert.Equal(t, testutils.SupportedRegions, res.BYOK.SupportedRegions)
+	})
+
+	t.Run("BYOK disabled, no stored keystore", func(t *testing.T) {
+		_, db, tenant := SetupTenantConfigManager(t)
+		r := sql.NewRepository(db)
+		m := manager.NewTenantConfigManager(r, nil, &config.Config{})
+		res, err := m.GetTenantsKeystores(testutils.CreateCtxWithTenant(tenant))
+		assert.NoError(t, err)
+		assert.Nil(t, res.BYOK.SupportedRegions)
+	})
+
+	t.Run("stored keystore: regions from keystore", func(t *testing.T) {
+		configManager, db, tenant := SetupTenantConfigManager(t)
+		ctx := testutils.CreateCtxWithTenant(tenant)
+
+		err := configManager.SetDefaultKeystore(ctx, testutils.NewKeystoreConfig(func(k *model.KeystoreConfig) {
+			k.SupportedRegions = testutils.SupportedRegions
+		}))
+		assert.NoError(t, err)
+
+		cfg := &config.Config{
+			BaseConfig: commoncfg.BaseConfig{
+				FeatureGates: commoncfg.FeatureGates{"allow-byok": true},
+			},
+		}
+		m := manager.NewTenantConfigManager(sql.NewRepository(db), nil, cfg)
+		res, err := m.GetTenantsKeystores(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, testutils.SupportedRegions, res.BYOK.SupportedRegions)
+	})
+
+	t.Run("BYOK allowed, bad source ref", func(t *testing.T) {
+		_, db, tenant := SetupTenantConfigManager(t)
+		cfg := &config.Config{
+			BaseConfig: commoncfg.BaseConfig{
+				FeatureGates: commoncfg.FeatureGates{"allow-byok": true},
+			},
+			KeystorePool: config.KeystorePool{
+				SupportedRegions: commoncfg.SourceRef{
+					Source: commoncfg.FileSourceValue,
+					Value:  "/nonexistent/regions.json",
+				},
+			},
+		}
+		m := manager.NewTenantConfigManager(sql.NewRepository(db), nil, cfg)
+		_, err := m.GetTenantsKeystores(testutils.CreateCtxWithTenant(tenant))
+		assert.Error(t, err)
+	})
 }
 
 func TestUpdateWorkflowConfig(t *testing.T) {


### PR DESCRIPTION
Note: SupportedRegions is a SourceRef so that it can be mounted under the same SourceRef for the plugin.