### PR TITLE
fix: add plugin watcher to detect dead plugin processes

### DIFF
--- a/cmd/event-reconciler/main.go
+++ b/cmd/event-reconciler/main.go
@@ -86,6 +86,7 @@ func run(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		log.Error(ctx, "Failed to load plugin", err)
 	}
+	svcRegistry.WatchPlugins(ctx)
 
 	ctx, err = cmkcontext.InjectInternalUserData(ctx, constants.InternalEventReconcilerRole)
 	if err != nil {

--- a/cmd/task-worker/main.go
+++ b/cmd/task-worker/main.go
@@ -128,6 +128,7 @@ func registerTasks(
 	if err != nil {
 		return errs.Wrapf(err, "failed to start loading catalog")
 	}
+	svcRegistry.WatchPlugins(ctx)
 
 	notifierClient, err := notifierclient.New(ctx, svcRegistry)
 	if err != nil {

--- a/cmd/tenant-manager/main.go
+++ b/cmd/tenant-manager/main.go
@@ -92,6 +92,7 @@ func run(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
+	svcRegistry.WatchPlugins(ctx)
 
 	r := sql.NewRepository(dbConn)
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -258,5 +258,7 @@ func makeController(
 	authzAPILoader.StartAuthzDataRefresh(ctx, AuthzRefreshInterval)
 	authzRepoLoader.StartAuthzDataRefresh(ctx, AuthzRefreshInterval)
 
+	svcRegistry.WatchPlugins(ctx)
+
 	return controller, nil
 }

--- a/internal/pluginregistry/export_test.go
+++ b/internal/pluginregistry/export_test.go
@@ -1,0 +1,22 @@
+package cmkpluginregistry
+
+import "context"
+
+// Exported for testing only.
+
+const (
+	PluginFailureThreshold     = pluginFailureThreshold
+	DefaultPluginWatchInterval = defaultPluginWatchInterval
+)
+
+func (w *PluginWatcher) SetShutdown(fn func(err error)) {
+	w.shutdown = fn
+}
+
+func (w *PluginWatcher) FailureCounts() map[string]int {
+	return w.failureCounts
+}
+
+func (w *PluginWatcher) Check(ctx context.Context) {
+	w.check(ctx)
+}

--- a/internal/pluginregistry/plugin_watcher.go
+++ b/internal/pluginregistry/plugin_watcher.go
@@ -1,0 +1,129 @@
+package cmkpluginregistry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"syscall"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+
+	pluginapi "github.com/openkcm/plugin-sdk/api"
+	plugincatalog "github.com/openkcm/plugin-sdk/pkg/catalog"
+
+	"github.com/openkcm/cmk/internal/errs"
+	"github.com/openkcm/cmk/internal/log"
+)
+
+const (
+	defaultPluginWatchInterval = 30 * time.Second
+	pluginPingTimeout          = 5 * time.Second
+	// pluginFailureThreshold is the number of consecutive failures before shutdown is triggered.
+	pluginFailureThreshold = 3
+
+	// goPluginHealthService is the service name go-plugin registers with the gRPC health server.
+	goPluginHealthService = "plugin"
+)
+
+var (
+	ErrPluginCheckFailed = errors.New("plugin health check failed")
+)
+
+// pluginLister is the subset of *catalog.Catalog used by PluginWatcher.
+type pluginLister interface {
+	ListPluginInfo() []pluginapi.Info
+	LookupByTypeAndName(pluginType, pluginName string) plugincatalog.Plugin
+}
+
+type PluginWatcher struct {
+	catalog       pluginLister
+	interval      time.Duration
+	shutdown      func(err error)
+	failureCounts map[string]int
+}
+
+func NewPluginWatcher(catalog pluginLister, interval time.Duration) *PluginWatcher {
+	if interval <= 0 {
+		interval = defaultPluginWatchInterval
+	}
+	return &PluginWatcher{
+		catalog:       catalog,
+		interval:      interval,
+		failureCounts: make(map[string]int),
+		shutdown: func(err error) {
+			_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		},
+	}
+}
+
+func (w *PluginWatcher) Start(ctx context.Context) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	w.check(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.check(ctx)
+		}
+	}
+}
+
+func (w *PluginWatcher) check(ctx context.Context) {
+	for _, info := range w.catalog.ListPluginInfo() {
+		plugin := w.catalog.LookupByTypeAndName(info.Type(), info.Name())
+		if plugin == nil {
+			continue
+		}
+
+		key := info.Type() + "/" + info.Name()
+
+		if err := w.ping(ctx, plugin); err != nil {
+			w.failureCounts[key]++
+			log.Warn(ctx, "Plugin health check failed",
+				slog.String("plugin", info.Name()),
+				slog.String("type", info.Type()),
+				slog.Int("consecutiveFailures", w.failureCounts[key]),
+				slog.Int("threshold", pluginFailureThreshold),
+				log.ErrorAttr(err),
+			)
+			if w.failureCounts[key] >= pluginFailureThreshold {
+				log.Error(ctx, "Plugin health check threshold reached, initiating shutdown",
+					err,
+					slog.String("plugin", info.Name()),
+					slog.String("type", info.Type()),
+				)
+				w.shutdown(err)
+				return
+			}
+		} else {
+			w.failureCounts[key] = 0
+		}
+	}
+}
+
+func (w *PluginWatcher) ping(ctx context.Context, plugin plugincatalog.Plugin) error {
+	pingCtx, cancel := context.WithTimeout(ctx, pluginPingTimeout)
+	defer cancel()
+
+	client := grpc_health_v1.NewHealthClient(plugin.ClientConnection())
+	resp, err := client.Check(pingCtx, &grpc_health_v1.HealthCheckRequest{Service: goPluginHealthService})
+	if err != nil {
+		// Built-in plugins use an in-process server that doesn't register the health service.
+		if status.Code(err) == codes.Unimplemented {
+			return nil
+		}
+		return errs.Wrap(ErrPluginCheckFailed, err)
+	}
+	if resp.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
+		return errs.Wrapf(ErrPluginCheckFailed, fmt.Sprintf("plugin %s is not serving", plugin.Info().Name()))
+	}
+	return nil
+}

--- a/internal/pluginregistry/plugin_watcher_test.go
+++ b/internal/pluginregistry/plugin_watcher_test.go
@@ -1,0 +1,204 @@
+package cmkpluginregistry_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+
+	pluginapi "github.com/openkcm/plugin-sdk/api"
+	plugincatalog "github.com/openkcm/plugin-sdk/pkg/catalog"
+
+	cmkpluginregistry "github.com/openkcm/cmk/internal/pluginregistry"
+)
+
+var errConnectionRefused = errors.New("connection refused")
+
+// fakePlugin implements plugincatalog.Plugin with a configurable ClientConnection.
+type fakePlugin struct {
+	info pluginapi.Info
+	conn grpc.ClientConnInterface
+}
+
+func (f *fakePlugin) Close() error                               { return nil }
+func (f *fakePlugin) ClientConnection() grpc.ClientConnInterface { return f.conn }
+func (f *fakePlugin) Info() pluginapi.Info                       { return f.info }
+func (f *fakePlugin) Logger() *slog.Logger                       { return slog.Default() }
+func (f *fakePlugin) GrpcServiceNames() []string                 { return nil }
+
+var _ plugincatalog.Plugin = (*fakePlugin)(nil)
+
+// fakeInfo implements pluginapi.Info.
+type fakeInfo struct {
+	name string
+	typ  string
+}
+
+func (f fakeInfo) Name() string   { return f.name }
+func (f fakeInfo) Type() string   { return f.typ }
+func (f fakeInfo) Tags() []string { return nil }
+func (f fakeInfo) Build() string  { return "" }
+func (f fakeInfo) Version() uint  { return 1 }
+
+var _ pluginapi.Info = fakeInfo{}
+
+// fakeCatalog implements the pluginLister interface via ListPluginInfo/LookupByTypeAndName.
+type fakeCatalog struct {
+	plugins map[string]plugincatalog.Plugin
+	infos   []pluginapi.Info
+}
+
+func (f *fakeCatalog) ListPluginInfo() []pluginapi.Info { return f.infos }
+func (f *fakeCatalog) LookupByTypeAndName(typ, name string) plugincatalog.Plugin {
+	return f.plugins[typ+"/"+name]
+}
+
+func newFakeCatalog(plugins ...*fakePlugin) *fakeCatalog {
+	c := &fakeCatalog{plugins: make(map[string]plugincatalog.Plugin)}
+	for _, p := range plugins {
+		c.infos = append(c.infos, p.info)
+		c.plugins[p.info.Type()+"/"+p.info.Name()] = p
+	}
+	return c
+}
+
+// fakeConn is a grpc.ClientConnInterface that delegates health checks to a handler func.
+type fakeConn struct {
+	grpc.ClientConnInterface
+
+	handler func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error
+}
+
+func (f *fakeConn) Invoke(ctx context.Context, method string, args, reply any, opts ...grpc.CallOption) error {
+	return f.handler(ctx, method, args, reply, nil, opts...)
+}
+
+func (f *fakeConn) NewStream(
+	_ context.Context,
+	_ *grpc.StreamDesc,
+	_ string,
+	_ ...grpc.CallOption,
+) (grpc.ClientStream, error) {
+	return nil, io.EOF
+}
+
+// healthyConn returns a conn whose health check always succeeds.
+func healthyConn() *fakeConn {
+	return &fakeConn{
+		handler: func(_ context.Context, _ string, _ any, reply any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			if r, ok := reply.(*grpc_health_v1.HealthCheckResponse); ok {
+				r.Status = grpc_health_v1.HealthCheckResponse_SERVING
+			}
+			return nil
+		},
+	}
+}
+
+// failingConn returns a conn whose health check always returns the given error.
+func failingConn(err error) *fakeConn {
+	return &fakeConn{
+		handler: func(_ context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			return err
+		},
+	}
+}
+
+// notServingConn returns a conn whose health check responds NOT_SERVING.
+func notServingConn() *fakeConn {
+	return &fakeConn{
+		handler: func(_ context.Context, _ string, _ any, reply any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			if r, ok := reply.(*grpc_health_v1.HealthCheckResponse); ok {
+				r.Status = grpc_health_v1.HealthCheckResponse_NOT_SERVING
+			}
+			return nil
+		},
+	}
+}
+
+func newWatcher(catalog *fakeCatalog) (*cmkpluginregistry.PluginWatcher, *int) {
+	w := cmkpluginregistry.NewPluginWatcher(catalog, cmkpluginregistry.DefaultPluginWatchInterval)
+	shutdownCount := 0
+	w.SetShutdown(func(err error) { shutdownCount++ })
+	return w, &shutdownCount
+}
+
+func TestPluginWatcher_HealthyPlugin(t *testing.T) {
+	plugin := &fakePlugin{info: fakeInfo{name: "kms", typ: "KeyManagement"}, conn: healthyConn()}
+	w, shutdownCount := newWatcher(newFakeCatalog(plugin))
+
+	w.Check(t.Context())
+
+	assert.Equal(t, 0, *shutdownCount)
+	assert.Equal(t, 0, w.FailureCounts()["KeyManagement/kms"])
+}
+
+func TestPluginWatcher_SingleFailureNoShutdown(t *testing.T) {
+	plugin := &fakePlugin{info: fakeInfo{name: "kms", typ: "KeyManagement"}, conn: failingConn(errConnectionRefused)}
+	w, shutdownCount := newWatcher(newFakeCatalog(plugin))
+
+	w.Check(t.Context())
+
+	assert.Equal(t, 0, *shutdownCount, "should not shutdown on first failure")
+	assert.Equal(t, 1, w.FailureCounts()["KeyManagement/kms"])
+}
+
+func TestPluginWatcher_ThresholdTriggersShutdown(t *testing.T) {
+	plugin := &fakePlugin{info: fakeInfo{name: "kms", typ: "KeyManagement"}, conn: failingConn(errConnectionRefused)}
+	w, shutdownCount := newWatcher(newFakeCatalog(plugin))
+
+	for range cmkpluginregistry.PluginFailureThreshold {
+		w.Check(t.Context())
+	}
+
+	assert.Equal(t, 1, *shutdownCount)
+	assert.Equal(t, cmkpluginregistry.PluginFailureThreshold, w.FailureCounts()["KeyManagement/kms"])
+}
+
+func TestPluginWatcher_FailureCounterResetsAfterRecovery(t *testing.T) {
+	plugin := &fakePlugin{info: fakeInfo{name: "kms", typ: "KeyManagement"}, conn: failingConn(errConnectionRefused)}
+	w, shutdownCount := newWatcher(newFakeCatalog(plugin))
+
+	// Two failures — below threshold
+	w.Check(t.Context())
+	w.Check(t.Context())
+	require.Equal(t, 2, w.FailureCounts()["KeyManagement/kms"])
+
+	// Recover
+	plugin.conn = healthyConn()
+	w.Check(t.Context())
+
+	assert.Equal(t, 0, *shutdownCount, "should not shutdown after recovery")
+	assert.Equal(t, 0, w.FailureCounts()["KeyManagement/kms"], "counter should reset")
+}
+
+func TestPluginWatcher_UnimplementedIsSkipped(t *testing.T) {
+	unimplErr := status.Error(codes.Unimplemented, "unknown service grpc.health.v1.Health")
+	plugin := &fakePlugin{info: fakeInfo{name: "noop", typ: "IdentityManagement"}, conn: failingConn(unimplErr)}
+	w, shutdownCount := newWatcher(newFakeCatalog(plugin))
+
+	for range cmkpluginregistry.PluginFailureThreshold {
+		w.Check(t.Context())
+	}
+
+	assert.Equal(t, 0, *shutdownCount, "Unimplemented should never trigger shutdown")
+	assert.Equal(t, 0, w.FailureCounts()["IdentityManagement/noop"], "Unimplemented should not increment counter")
+}
+
+func TestPluginWatcher_NotServingTriggersShutdown(t *testing.T) {
+	plugin := &fakePlugin{info: fakeInfo{name: "kms", typ: "KeyManagement"}, conn: notServingConn()}
+	w, shutdownCount := newWatcher(newFakeCatalog(plugin))
+
+	for range cmkpluginregistry.PluginFailureThreshold {
+		w.Check(t.Context())
+	}
+
+	assert.Equal(t, 1, *shutdownCount)
+}

--- a/internal/pluginregistry/registry.go
+++ b/internal/pluginregistry/registry.go
@@ -1,6 +1,8 @@
 package cmkpluginregistry
 
 import (
+	"context"
+
 	plugincatalog "github.com/openkcm/plugin-sdk/pkg/catalog"
 
 	serviceapi "github.com/openkcm/cmk/internal/pluginregistry/service/api"
@@ -13,4 +15,11 @@ type Registry struct {
 
 func (p *Registry) Close() error {
 	return p.Registry.Close()
+}
+
+// WatchPlugins starts the plugin health watcher as a background goroutine.
+// On detecting a dead plugin it sends SIGTERM to trigger graceful shutdown.
+func (p *Registry) WatchPlugins(ctx context.Context) {
+	watcher := NewPluginWatcher(p.Catalog, defaultPluginWatchInterval)
+	go watcher.Start(ctx)
 }


### PR DESCRIPTION
Plugin processes can crash and not recoverable from main components, so they cannot be used. This provides a solution that will kill the whole pod so everything can be brought up fresh.
