### PR TITLE
feat: add Content-Security-Policy header to API responses

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -207,7 +207,9 @@ func createHTTPServer(
 				// SecurityHeadersMiddleware is last in the slice so it runs first (FILO order).
 				// Security headers must be set before any other middleware runs to ensure
 				// they appear on every response, including error responses.
-				commonmiddleware.SecurityHeadersMiddleware(nil),
+				commonmiddleware.SecurityHeadersMiddleware(map[string]string{
+					"Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none';",
+				}),
 			},
 		},
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
``` 
Adds Content-Security-Policy header to all API responses via SecurityHeadersMiddleware.

CSP value: default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'

The middleware sits last in the slice so it executes first (FILO order), ensuring the header is present on every response including error responses.

Required for SEC-390 compliance.
```

**Release note**:
``` NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened browser security headers on HTTP responses, including error pages, to reduce the risk of content injection and framing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->