### PR TITLE
fix: unify labels and tags via resource_labels

### DIFF
--- a/cmd/task-worker/main.go
+++ b/cmd/task-worker/main.go
@@ -158,7 +158,8 @@ func registerTasks(
 	userManager := manager.NewUserManager(authzRepo, cmkAuditor)
 	certManager := manager.NewCertificateManager(ctx, authzRepo, svcRegistry, cfg)
 	tenantConfigManager := manager.NewTenantConfigManager(authzRepo, svcRegistry, cfg)
-	tagManager := manager.NewTagManager(authzRepo)
+	resourceLabelManager := manager.NewResourceLabelManager(authzRepo)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 	keyConfigManager := manager.NewKeyConfigManager(
 		authzRepo,
 		certManager,

--- a/cmd/tenant-manager-cli/cli_test.go
+++ b/cmd/tenant-manager-cli/cli_test.go
@@ -79,7 +79,8 @@ func (s *CLISuite) SetupSuite() {
 
 	cm := manager.NewCertificateManager(ctx, authzRepo, svcRegistry, cfg)
 	um := manager.NewUserManager(authzRepo, cmkAuditor)
-	tagm := manager.NewTagManager(authzRepo)
+	resourceLabelManager := manager.NewResourceLabelManager(authzRepo)
+	tagm := manager.NewTagManager(resourceLabelManager)
 	kcm := manager.NewKeyConfigManager(authzRepo, cm, um, tagm, cmkAuditor, eventFactory, cfg)
 
 	sys := manager.NewSystemManager(

--- a/cmd/tenant-manager-cli/commands/commands.go
+++ b/cmd/tenant-manager-cli/commands/commands.go
@@ -58,7 +58,8 @@ func NewCommandFactory(
 
 	cm := manager.NewCertificateManager(ctx, authzRepo, svcRegistry, cfg)
 	um := manager.NewUserManager(authzRepo, cmkAuditor)
-	tagm := manager.NewTagManager(authzRepo)
+	resourceLabelManager := manager.NewResourceLabelManager(authzRepo)
+	tagm := manager.NewTagManager(resourceLabelManager)
 	kcm := manager.NewKeyConfigManager(authzRepo, cm, um, tagm, cmkAuditor, eventFactory, cfg)
 
 	sys := manager.NewSystemManager(

--- a/cmd/tenant-manager/main.go
+++ b/cmd/tenant-manager/main.go
@@ -146,7 +146,8 @@ func createTenantManager(
 	cm := manager.NewCertificateManager(ctx, r, svcRegistry, cfg)
 	um := manager.NewUserManager(r, cmkAuditor)
 
-	tagm := manager.NewTagManager(r)
+	resourceLabelManager := manager.NewResourceLabelManager(r)
+	tagm := manager.NewTagManager(resourceLabelManager)
 	kcm := manager.NewKeyConfigManager(r, cm, um, tagm, cmkAuditor, eventFactory, cfg)
 
 	sys := manager.NewSystemManager(

--- a/cmd/tenant-manager/main_test.go
+++ b/cmd/tenant-manager/main_test.go
@@ -3,6 +3,7 @@ package main_test
 import (
 	"context"
 	"errors"
+	"net"
 	"os"
 	"testing"
 
@@ -205,6 +206,11 @@ func TestBusinessMain(t *testing.T) {
 	}
 
 	t.Run("valid configuration", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		statusAddr := ln.Addr().String()
+		require.NoError(t, ln.Close())
+
 		cfg := &config.Config{
 			TenantManager: config.TenantManager{
 				SecretRef: commoncfg.SecretRef{
@@ -224,7 +230,7 @@ func TestBusinessMain(t *testing.T) {
 				},
 				Status: commoncfg.Status{
 					Enabled: true,
-					Address: ":8888",
+					Address: statusAddr,
 				},
 			},
 		}

--- a/internal/async/tasks/tenant/workflow_expiry_test.go
+++ b/internal/async/tasks/tenant/workflow_expiry_test.go
@@ -120,7 +120,8 @@ func setupWorkflowExpiry(t *testing.T) (*manager.WorkflowManager, repo.Repo, str
 	tenantConfigManager := manager.NewTenantConfigManager(r, svcRegistry, nil)
 	cmkAuditor := auditor.New(t.Context(), cfg)
 	userManager := manager.NewUserManager(r, cmkAuditor)
-	tagManager := manager.NewTagManager(r)
+	resourceLabelManager := manager.NewResourceLabelManager(r)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 	keyConfigManager := manager.NewKeyConfigManager(r, certManager, userManager, tagManager, cmkAuditor, eventFactory, cfg)
 	groupManager := manager.NewGroupManager(r, svcRegistry, userManager)
 

--- a/internal/authz/policies.go
+++ b/internal/authz/policies.go
@@ -44,6 +44,7 @@ const (
 	RepoResourceTypeKeystore         RepoResourceType = RepoResourceType(constants.KeystoreTable)
 	RepoResourceTypeKeyversion       RepoResourceType = RepoResourceType(constants.KeyVersionTable)
 	RepoResourceTypeKeyLabel         RepoResourceType = RepoResourceType(constants.KeyLabelTable)
+	RepoResourceTypeResourceLabel    RepoResourceType = RepoResourceType(constants.ResourceLabelTable)
 	RepoResourceTypeSystem           RepoResourceType = RepoResourceType(constants.SystemTable)
 	RepoResourceTypeSystemProperty   RepoResourceType = RepoResourceType(constants.SystemPropertyTable)
 	RepoResourceTypeTag              RepoResourceType = RepoResourceType(constants.TagTable)
@@ -97,6 +98,7 @@ var RepoResourceTypeActions = map[RepoResourceType][]RepoAction{
 	RepoResourceTypeKeystore:         repoActionList,
 	RepoResourceTypeKeyversion:       repoActionList,
 	RepoResourceTypeKeyLabel:         repoActionList,
+	RepoResourceTypeResourceLabel:    repoActionList,
 	RepoResourceTypeSystem:           repoActionList,
 	RepoResourceTypeSystemProperty:   repoActionList,
 	RepoResourceTypeTag:              repoActionList,

--- a/internal/authz/policy_tests/hyok_sync_test.go
+++ b/internal/authz/policy_tests/hyok_sync_test.go
@@ -57,7 +57,8 @@ func TestHYOKSync_AuthzPolicy(t *testing.T) {
 	cmkAuditor := auditor.New(t.Context(), cfg)
 	certManager := manager.NewCertificateManager(t.Context(), authzRepo, ps, cfg)
 	tenantConfigManager := manager.NewTenantConfigManager(authzRepo, ps, cfg)
-	tagManager := manager.NewTagManager(authzRepo)
+	resourceLabelManager := manager.NewResourceLabelManager(authzRepo)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 	userManager := manager.NewUserManager(authzRepo, cmkAuditor)
 	keyConfigManager := manager.NewKeyConfigManager(authzRepo, certManager, userManager, tagManager, cmkAuditor, eventFactory, cfg)
 

--- a/internal/authz/policy_tests/keystore_pool_test.go
+++ b/internal/authz/policy_tests/keystore_pool_test.go
@@ -59,7 +59,8 @@ func TestKeystorePool_AuthzPolicy(t *testing.T) {
 	cmkAuditor := auditor.New(t.Context(), cfg)
 	userManager := manager.NewUserManager(authzRepo, cmkAuditor)
 	certManager := manager.NewCertificateManager(t.Context(), authzRepo, ps, cfg)
-	tagManager := manager.NewTagManager(authzRepo)
+	resourceLabelManager := manager.NewResourceLabelManager(authzRepo)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 	tenantConfigManager := manager.NewTenantConfigManager(authzRepo, ps, cfg)
 	keyConfigManager := manager.NewKeyConfigManager(authzRepo, certManager, userManager, tagManager, cmkAuditor, eventFactory, cfg)
 	keyManager := manager.NewKeyManager(

--- a/internal/authz/policy_tests/workflow_autoassign_test.go
+++ b/internal/authz/policy_tests/workflow_autoassign_test.go
@@ -70,7 +70,8 @@ func TestWorkflowAutoAssign_AuthzPolicy(t *testing.T) {
 	cmkAuditor := auditor.New(t.Context(), cfg)
 	userManager := manager.NewUserManager(authzRepo, cmkAuditor)
 	certManager := manager.NewCertificateManager(t.Context(), authzRepo, ps, cfg)
-	tagManager := manager.NewTagManager(authzRepo)
+	resourceLabelManager := manager.NewResourceLabelManager(authzRepo)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 	tenantConfigManager := manager.NewTenantConfigManager(authzRepo, ps, cfg)
 	keyConfigManager := manager.NewKeyConfigManager(authzRepo, certManager, userManager, tagManager, cmkAuditor, eventFactory, cfg)
 	keyManager := manager.NewKeyManager(

--- a/internal/authz/repo_business_policies.go
+++ b/internal/authz/repo_business_policies.go
@@ -80,6 +80,14 @@ var RepoBusinessPolicies = RolePolicies[constants.BusinessRole, RepoResourceType
 					},
 				},
 				{
+					Type: RepoResourceTypeResourceLabel,
+					Actions: []RepoAction{
+						RepoActionList,
+						RepoActionFirst,
+						RepoActionCount,
+					},
+				},
+				{
 					Type: RepoResourceTypeSystem,
 					Actions: []RepoAction{
 						RepoActionList,
@@ -229,6 +237,17 @@ var RepoBusinessPolicies = RolePolicies[constants.BusinessRole, RepoResourceType
 				},
 				{
 					Type: RepoResourceTypeKeyLabel,
+					Actions: []RepoAction{
+						RepoActionList,
+						RepoActionFirst,
+						RepoActionCount,
+						RepoActionCreate,
+						RepoActionUpdate,
+						RepoActionDelete,
+					},
+				},
+				{
+					Type: RepoResourceTypeResourceLabel,
 					Actions: []RepoAction{
 						RepoActionList,
 						RepoActionFirst,

--- a/internal/constants/table-names.go
+++ b/internal/constants/table-names.go
@@ -12,6 +12,7 @@ const (
 	KeystoreTable         = publicTablePreFix + "keystore_pool"
 	KeyVersionTable       = "key_versions"
 	KeyLabelTable         = "key_labels"
+	ResourceLabelTable    = "resource_labels"
 	SystemTable           = "systems"
 	SystemPropertyTable   = "systems_properties"
 	TagTable              = "tags"

--- a/internal/controllers/cmk/key_labels_controller_test.go
+++ b/internal/controllers/cmk/key_labels_controller_test.go
@@ -106,21 +106,24 @@ func TestLabelsController_GetKeyLabels(t *testing.T) {
 		key := testutils.NewKey(func(k *model.Key) {
 			k.ID = keyID
 			k.KeyConfigurationID = keyConfig.ID
-			k.KeyLabels = []model.KeyLabel{
-				*testutils.NewKeyLabel(func(l *model.KeyLabel) {
-					l.Key = "foo"
-					l.Value = "bar"
-					l.ResourceID = keyID
-				}),
-				*testutils.NewKeyLabel(func(l *model.KeyLabel) {
-					l.Key = "region/az"
-					l.Value = "eu-west-1/a"
-					l.ResourceID = keyID
-				}),
-			}
 		})
 
-		testutils.CreateTestEntities(ctx, t, r, keyConfig, key)
+		rl1 := &model.ResourceLabel{
+			ID:           uuid.New(),
+			ResourceType: model.ResourceTypeKey,
+			ResourceID:   keyID,
+			Key:          "foo",
+			Value:        "bar",
+		}
+		rl2 := &model.ResourceLabel{
+			ID:           uuid.New(),
+			ResourceType: model.ResourceTypeKey,
+			ResourceID:   keyID,
+			Key:          "region/az",
+			Value:        "eu-west-1/a",
+		}
+
+		testutils.CreateTestEntities(ctx, t, r, keyConfig, key, rl1, rl2)
 
 		w := testutils.MakeHTTPRequest(t, sv, testutils.RequestOptions{
 			Method:   http.MethodGet,
@@ -169,12 +172,6 @@ func TestLabelsController_GetKeyLabelsPagination(t *testing.T) {
 	r := sql.NewRepository(db)
 
 	key := testutils.NewKey(func(_ *model.Key) {})
-	for range totalRecordCount {
-		key.KeyLabels = append(
-			key.KeyLabels,
-			*testutils.NewKeyLabel(func(_ *model.KeyLabel) {}),
-		)
-	}
 
 	authClient := testutils.NewAuthClient(ctx, t, r, testutils.WithKeyAdminRole())
 	headers := signedHeadersForAuthClient(t, keyStorage, authClient)
@@ -183,6 +180,16 @@ func TestLabelsController_GetKeyLabelsPagination(t *testing.T) {
 		testutils.WithAuthBusinessUserDataKC(authClient))
 
 	testutils.CreateTestEntities(ctx, t, r, keyConfig, key)
+	for i := range totalRecordCount {
+		label := &model.ResourceLabel{
+			ID:           uuid.New(),
+			ResourceType: model.ResourceTypeKey,
+			ResourceID:   key.ID,
+			Key:          fmt.Sprintf("key-%03d", i),
+			Value:        fmt.Sprintf("value-%03d", i),
+		}
+		testutils.CreateTestEntities(ctx, t, r, label)
+	}
 
 	type testCase struct {
 		name           string
@@ -430,15 +437,16 @@ func TestLabelsController_CreateOrUpdateLabels(t *testing.T) {
 			assert.Equal(t, tc.expectedStatus, w.Code)
 
 			if tc.validateByFetchingDataFromDB && tc.doesKeyExist {
-				var ls []*model.KeyLabel
+				var ls []*model.ResourceLabel
 
-				err := r.List(ctx, model.KeyLabel{}, &ls, *repo.NewQuery().Order(repo.OrderField{
+				err := r.List(ctx, model.ResourceLabel{}, &ls, *repo.NewQuery().Order(repo.OrderField{
 					Field:     "Key",
 					Direction: repo.Asc,
 				}).Where(
 					repo.NewCompositeKeyGroup(
-						repo.NewCompositeKey().Where(
-							repo.ResourceIDField, key.ID),
+						repo.NewCompositeKey().
+							Where(repo.ResourceTypeField, model.ResourceTypeKey).
+							Where(repo.ResourceIDField, key.ID),
 					),
 				))
 				assert.NoError(t, err)
@@ -510,20 +518,23 @@ func TestLabelsController_DeleteLabel(t *testing.T) {
 				keyID := uuid.New()
 				key = testutils.NewKey(func(k *model.Key) {
 					k.ID = keyID
-					k.KeyLabels = []model.KeyLabel{
-						*testutils.NewKeyLabel(func(l *model.KeyLabel) {
-							l.Key = "foo"
-							l.Value = "bar"
-							l.ResourceID = keyID
-						}),
-						*testutils.NewKeyLabel(func(l *model.KeyLabel) {
-							l.Key = "region/az"
-							l.Value = "eu-west-1/a"
-							l.ResourceID = keyID
-						}),
-					}
 				})
-				testutils.CreateTestEntities(ctx, t, r, key)
+				rl1 := &model.ResourceLabel{
+					ID:           uuid.New(),
+					ResourceType: model.ResourceTypeKey,
+					ResourceID:   keyID,
+					Key:          "foo",
+					Value:        "bar",
+				}
+				rl2 := &model.ResourceLabel{
+					ID:           uuid.New(),
+					ResourceType: model.ResourceTypeKey,
+					ResourceID:   keyID,
+					Key:          "region/az",
+					Value:        "eu-west-1/a",
+				}
+
+				testutils.CreateTestEntities(ctx, t, r, key, rl1, rl2)
 			} else {
 				key = testutils.NewKey(func(_ *model.Key) {})
 			}
@@ -537,15 +548,16 @@ func TestLabelsController_DeleteLabel(t *testing.T) {
 			assert.Equal(t, tc.expectedStatus, w.Code)
 
 			if tc.validateByFetchingDataFromDB && tc.doesKeyExist {
-				var ls []*model.KeyLabel
+				var ls []*model.ResourceLabel
 
-				err := r.List(ctx, model.KeyLabel{}, &ls, *repo.NewQuery().Order(repo.OrderField{
+				err := r.List(ctx, model.ResourceLabel{}, &ls, *repo.NewQuery().Order(repo.OrderField{
 					Field:     "Key",
 					Direction: repo.Asc,
 				}).Where(
 					repo.NewCompositeKeyGroup(
-						repo.NewCompositeKey().Where(
-							repo.ResourceIDField, key.ID),
+						repo.NewCompositeKey().
+							Where(repo.ResourceTypeField, model.ResourceTypeKey).
+							Where(repo.ResourceIDField, key.ID),
 					),
 				))
 				assert.NoError(t, err)

--- a/internal/controllers/cmk/keyconfiguration_tags_controller_test.go
+++ b/internal/controllers/cmk/keyconfiguration_tags_controller_test.go
@@ -1,11 +1,11 @@
 package cmk_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/openkcm/common-sdk/pkg/auth"
 	"github.com/stretchr/testify/assert"
 
@@ -40,19 +40,27 @@ func TestGetTagsForKeyConfiguration(t *testing.T) {
 	r := sql.NewRepository(db)
 
 	tags := []string{"tag1", "tag2"}
-	bytes, err := json.Marshal(tags)
-	assert.NoError(t, err)
 
 	authClient := testutils.NewAuthClient(ctx, t, r, testutils.WithKeyAdminRole())
 
 	keyConfig := testutils.NewKeyConfig(func(*model.KeyConfiguration) {},
 		testutils.WithAuthBusinessUserDataKC(authClient))
 
-	tag := testutils.NewTag(func(t *model.Tag) {
-		t.ID = keyConfig.ID
-		t.Values = bytes
-	})
-	testutils.CreateTestEntities(ctx, t, r, keyConfig, tag)
+	tag1 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKeyConfig,
+		ResourceID:   keyConfig.ID,
+		Key:          model.SystemTagKey,
+		Value:        tags[0],
+	}
+	tag2 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKeyConfig,
+		ResourceID:   keyConfig.ID,
+		Key:          model.SystemTagKey,
+		Value:        tags[1],
+	}
+	testutils.CreateTestEntities(ctx, t, r, keyConfig, tag1, tag2)
 
 	clientData := &auth.ClientData{
 		Identifier: authClient.Identifier,
@@ -185,14 +193,18 @@ func TestAddTagsToKeyConfiguration(t *testing.T) {
 			assert.Equal(t, tt.expectedStatus, w.Code)
 
 			if tt.expectedStatus == http.StatusNoContent {
-				tag := &model.Tag{ID: keyConfig.ID}
-
-				_, err := r.First(ctx, tag, *repo.NewQuery())
+				labels := []*model.ResourceLabel{}
+				ck := repo.NewCompositeKey().
+					Where(repo.ResourceTypeField, model.ResourceTypeKeyConfig).
+					Where(repo.ResourceIDField, keyConfig.ID).
+					Where(repo.KeyField, model.SystemTagKey)
+				err := r.List(ctx, &model.ResourceLabel{}, &labels, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
 				assert.NoError(t, err)
 
-				resTags := []string{}
-				err = json.Unmarshal(tag.Values, &resTags)
-				assert.NoError(t, err)
+				resTags := make([]string, 0, len(labels))
+				for _, l := range labels {
+					resTags = append(resTags, l.Value)
+				}
 				assert.ElementsMatch(t, tt.expectedTagValues, resTags)
 			}
 		})

--- a/internal/manager/base.go
+++ b/internal/manager/base.go
@@ -52,7 +52,11 @@ func New(
 	certManager := NewCertificateManager(ctx, repo, svcRegistry, config)
 	tenantConfigManager := NewTenantConfigManager(repo, svcRegistry, config)
 	userManager := NewUserManager(repo, cmkAuditor)
-	tagManager := NewTagManager(repo)
+
+	// Create ResourceLabelManager for unified label/tag management
+	resourceLabelManager := NewResourceLabelManager(repo)
+	tagManager := NewTagManager(resourceLabelManager)
+
 	keyConfigManager := NewKeyConfigManager(repo, certManager, userManager, tagManager, cmkAuditor, eventFactory, config)
 	keyManager := NewKeyManager(
 		repo,
@@ -83,8 +87,8 @@ func New(
 		TenantConfigs: tenantConfigManager,
 		System:        systemManager,
 		KeyConfig:     keyConfigManager,
-		Tags:          NewTagManager(repo),
-		Labels:        NewLabelManager(repo),
+		Tags:          tagManager,
+		Labels:        NewLabelManager(repo, resourceLabelManager),
 		Workflow: NewWorkflowManager(
 			repo,
 			svcRegistry,

--- a/internal/manager/errors.go
+++ b/internal/manager/errors.go
@@ -23,6 +23,7 @@ var (
 
 	ErrGetTags      = errors.New("failed getting tags")
 	ErrDeletingTags = errors.New("failed to delete tags")
+	ErrCreateTag    = errors.New("error setting tags")
 
 	ErrCreateKeyConfiguration       = errors.New("failed to create key configuration")
 	ErrConnectedSystemToKeyConfig   = errors.New("system is connected to keyconfig")

--- a/internal/manager/key_label.go
+++ b/internal/manager/key_label.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"errors"
 
 	"github.com/google/uuid"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/openkcm/cmk/internal/repo"
 )
 
+// Label interface for managing labels on keys
 type Label interface {
 	GetKeyLabels(
 		ctx context.Context,
@@ -29,18 +29,25 @@ type Label interface {
 	) (bool, error)
 }
 
+// LabelManager is an adapter that delegates to ResourceLabelManager
+// Maintains backward compatibility while using the new unified resource_labels table
 type LabelManager struct {
-	repository repo.Repo
+	repository     repo.Repo
+	resourceLabels ResourceLabels
 }
 
+// NewLabelManager creates a new LabelManager that uses ResourceLabelManager
 func NewLabelManager(
 	repository repo.Repo,
+	resourceLabels ResourceLabels,
 ) *LabelManager {
 	return &LabelManager{
-		repository: repository,
+		repository:     repository,
+		resourceLabels: resourceLabels,
 	}
 }
 
+// DeleteLabel removes a label by key name for a specific key
 func (m *LabelManager) DeleteLabel(
 	ctx context.Context,
 	keyID uuid.UUID,
@@ -50,37 +57,24 @@ func (m *LabelManager) DeleteLabel(
 		return false, ErrEmptyInputLabelDB
 	}
 
+	// Verify key exists
 	key := &model.Key{ID: keyID}
-
 	_, err := m.repository.First(ctx, key, *repo.NewQuery())
 	if err != nil {
 		return false, errs.Wrap(ErrGetKeyIDDB, err)
 	}
 
-	label := &model.KeyLabel{}
-
-	ck := repo.NewCompositeKey().
-		Where(repo.KeyField, labelName).
-		Where(repo.ResourceIDField, keyID)
-
-	ok, err := m.repository.Delete(
-		ctx,
-		label,
-		*repo.NewQuery().
-			Where(repo.NewCompositeKeyGroup(ck)),
-	)
-	if err != nil {
-		return false, errs.Wrap(ErrDeleteLabelDB, err)
-	}
-
-	return ok, nil
+	// Delete label using ResourceLabelManager
+	return m.resourceLabels.DeleteLabel(ctx, model.ResourceTypeKey, keyID, labelName)
 }
 
+// CreateOrUpdateLabel creates or updates labels for a key
 func (m *LabelManager) CreateOrUpdateLabel(
 	ctx context.Context,
 	keyID uuid.UUID,
 	labels []*model.KeyLabel,
 ) error {
+	// Verify key exists
 	key := &model.Key{ID: keyID}
 	ck := repo.NewCompositeKey().Where(repo.IDField, keyID)
 
@@ -90,65 +84,57 @@ func (m *LabelManager) CreateOrUpdateLabel(
 		return errs.Wrap(ErrGettingKeyByID, err)
 	}
 
-	err = m.repository.Transaction(ctx, func(ctx context.Context) error {
-		for _, label := range labels {
-			l := &model.KeyLabel{}
-			ck = repo.NewCompositeKey().Where(repo.KeyField, label.Key).Where(repo.ResourceIDField, keyID)
-
-			_, err := m.repository.First(
-				ctx,
-				l,
-				*repo.NewQuery().
-					Where(repo.NewCompositeKeyGroup(ck)),
-			)
-			if err != nil {
-				if !errors.Is(err, repo.ErrNotFound) {
-					return errs.Wrap(ErrFetchLabel, err)
-				}
-
-				err := m.repository.Create(ctx, label)
-				if err != nil {
-					return errs.Wrap(ErrInsertLabel, err)
-				}
-			} else {
-				l.Value = label.Value
-
-				_, err := m.repository.Patch(
-					ctx,
-					l,
-					*repo.NewQuery().UpdateAll(true),
-				)
-				if err != nil {
-					return errs.Wrap(ErrUpdateLabelDB, err)
-				}
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
-		return errs.Wrap(ErrUpdateLabelDB, err)
+	// Convert KeyLabel to ResourceLabel
+	resourceLabels := make([]*model.ResourceLabel, 0, len(labels))
+	for _, label := range labels {
+		resourceLabels = append(resourceLabels, &model.ResourceLabel{
+			ID:           label.ID,
+			ResourceType: model.ResourceTypeKey,
+			ResourceID:   keyID,
+			Key:          label.Key,
+			Value:        label.Value,
+		})
 	}
 
-	return nil
+	// Delegate to ResourceLabelManager
+	return m.resourceLabels.CreateOrUpdateLabels(ctx, model.ResourceTypeKey, keyID, resourceLabels)
 }
 
+// GetKeyLabels retrieves all labels for a key with pagination
 func (m *LabelManager) GetKeyLabels(
 	ctx context.Context,
 	keyID uuid.UUID,
 	pagination repo.Pagination,
 ) ([]*model.KeyLabel, int, error) {
+	// Verify key exists
 	key := &model.Key{ID: keyID}
-
 	_, err := m.repository.First(ctx, key, *repo.NewQuery())
 	if err != nil {
 		return nil, 0, errs.Wrap(ErrGettingKeyByID, err)
 	}
 
-	ck := repo.NewCompositeKey().
-		Where(repo.ResourceIDField, keyID)
+	// Get labels from ResourceLabelManager
+	resourceLabels, count, err := m.resourceLabels.GetLabels(ctx, model.ResourceTypeKey, keyID, pagination)
+	if err != nil {
+		return nil, 0, err
+	}
 
-	query := repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck))
+	// Convert ResourceLabel back to KeyLabel for backward compatibility
+	keyLabels := make([]*model.KeyLabel, 0, len(resourceLabels))
+	for _, rl := range resourceLabels {
+		keyLabels = append(keyLabels, &model.KeyLabel{
+			BaseLabel: model.BaseLabel{
+				ID:         rl.ID,
+				Key:        rl.Key,
+				Value:      rl.Value,
+				ResourceID: rl.ResourceID,
+			},
+			AutoTimeModel: model.AutoTimeModel{
+				CreatedAt: rl.CreatedAt,
+				UpdatedAt: rl.UpdatedAt,
+			},
+		})
+	}
 
-	return repo.ListAndCount(ctx, m.repository, pagination, model.KeyLabel{}, query)
+	return keyLabels, count, nil
 }

--- a/internal/manager/key_label_test.go
+++ b/internal/manager/key_label_test.go
@@ -24,17 +24,23 @@ func TestGetKeyLabels(t *testing.T) {
 	keyID := uuid.New()
 	key := testutils.NewKey(func(k *model.Key) {
 		k.ID = keyID
-		k.KeyLabels = []model.KeyLabel{
-			*testutils.NewKeyLabel(func(l *model.KeyLabel) {
-				l.ResourceID = keyID
-			}),
-			*testutils.NewKeyLabel(func(l *model.KeyLabel) {
-				l.ResourceID = keyID
-			}),
-		}
 	})
 	key2 := testutils.NewKey(func(_ *model.Key) {})
-	testutils.CreateTestEntities(ctx, t, r, key, key2)
+	rl1 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKey,
+		ResourceID:   keyID,
+		Key:          "foo",
+		Value:        "bar",
+	}
+	rl2 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKey,
+		ResourceID:   keyID,
+		Key:          "region/az",
+		Value:        "eu-west-1/a",
+	}
+	testutils.CreateTestEntities(ctx, t, r, key, key2, rl1, rl2)
 
 	t.Run("Should get key labels", func(t *testing.T) {
 		labels, count, err := m.GetKeyLabels(
@@ -44,11 +50,11 @@ func TestGetKeyLabels(t *testing.T) {
 		)
 		assert.NoError(t, err)
 
-		for i := range labels {
-			assert.Equal(t, key.KeyLabels[i].ResourceID, labels[i].ResourceID)
+		assert.Len(t, labels, 2)
+		for _, l := range labels {
+			assert.Equal(t, keyID, l.ResourceID)
 		}
-
-		assert.Equal(t, len(key.KeyLabels), count)
+		assert.Equal(t, 2, count)
 	})
 
 	t.Run("Should error getting key labels on invalid key", func(t *testing.T) {
@@ -73,9 +79,8 @@ func TestCreateOrUpdateLabel(t *testing.T) {
 	expected := []*model.KeyLabel{
 		{
 			BaseLabel: model.BaseLabel{
-				ID:    uuid.New(),
 				Value: "test-1",
-				Key:   key.ID.String(),
+				Key:   "test-key",
 			},
 			CryptoKey: *key,
 		},
@@ -94,7 +99,8 @@ func TestCreateOrUpdateLabel(t *testing.T) {
 		assert.NoError(t, err)
 
 		for i := range labels {
-			assert.Equal(t, expected[i].BaseLabel, labels[i].BaseLabel)
+			assert.Equal(t, expected[i].Key, labels[i].Key)
+			assert.Equal(t, expected[i].Value, labels[i].Value)
 		}
 	})
 	t.Run("Should update labels", func(t *testing.T) {
@@ -142,19 +148,17 @@ func TestDeleteKeyLabel(t *testing.T) {
 	keyID := uuid.New()
 	key := testutils.NewKey(func(k *model.Key) {
 		k.ID = keyID
-		k.KeyLabels = []model.KeyLabel{
-			*testutils.NewKeyLabel(func(l *model.KeyLabel) {
-				l.ResourceID = keyID
-			}),
-			*testutils.NewKeyLabel(func(l *model.KeyLabel) {
-				l.ResourceID = keyID
-			}),
-		}
 	})
 
 	testutils.CreateTestEntities(ctx, t, r, key)
+	err := m.CreateOrUpdateLabel(ctx, key.ID, []*model.KeyLabel{
+		{BaseLabel: model.BaseLabel{Key: "foo", Value: "bar"}},
+		{BaseLabel: model.BaseLabel{Key: "region/az", Value: "eu-west-1/a"}},
+	})
+	assert.NoError(t, err)
+
 	t.Run("Should delete label", func(t *testing.T) {
-		ok, err := m.DeleteLabel(ctx, key.ID, key.KeyLabels[0].Key)
+		ok, err := m.DeleteLabel(ctx, key.ID, "foo")
 		assert.NoError(t, err)
 		assert.True(t, ok)
 
@@ -173,7 +177,7 @@ func TestDeleteKeyLabel(t *testing.T) {
 	})
 
 	t.Run("Should error invalid key id", func(t *testing.T) {
-		_, err := m.DeleteLabel(ctx, uuid.New(), key.KeyLabels[0].Key)
+		_, err := m.DeleteLabel(ctx, uuid.New(), "foo")
 		assert.ErrorIs(t, err, manager.ErrGetKeyIDDB)
 	})
 }
@@ -184,7 +188,8 @@ func setupTest(t *testing.T) (*multitenancy.DB, *manager.LabelManager, string) {
 	db, tenants, _ := testutils.NewTestDB(t, testutils.TestDBConfig{})
 
 	r := sql.NewRepository(db)
-	labelManager := manager.NewLabelManager(r)
+	resourceLabelManager := manager.NewResourceLabelManager(r)
+	labelManager := manager.NewLabelManager(r, resourceLabelManager)
 
 	return db, labelManager, tenants[0]
 }

--- a/internal/manager/key_test.go
+++ b/internal/manager/key_test.go
@@ -86,7 +86,8 @@ func SetupKeyTest(t *testing.T) (
 	tenantConfigManager := manager.NewTenantConfigManager(r, svcRegistry, nil)
 	certManager := manager.NewCertificateManager(ctx, r, svcRegistry, cfg)
 	userManager := manager.NewUserManager(r, cmkAuditor)
-	tagManager := manager.NewTagManager(r)
+	resourceLabelManager := manager.NewResourceLabelManager(r)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 	keyConfigManager := manager.NewKeyConfigManager(r, certManager, userManager, tagManager, cmkAuditor, eventFactory, cfg)
 
 	km := manager.NewKeyManager(
@@ -1265,7 +1266,8 @@ func TestKeyRotationTime(t *testing.T) {
 	tenantConfigManager := manager.NewTenantConfigManager(r, svcRegistry, nil)
 	certManager := manager.NewCertificateManager(ctx, r, svcRegistry, cfg)
 	userManager := manager.NewUserManager(r, cmkAuditor)
-	tagManager := manager.NewTagManager(r)
+	resourceLabelManager := manager.NewResourceLabelManager(r)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 	keyConfigManager := manager.NewKeyConfigManager(r, certManager, userManager, tagManager, cmkAuditor, eventFactory, cfg)
 	km := manager.NewKeyManager(r, svcRegistry, tenantConfigManager, keyConfigManager, userManager, certManager, nil, cmkAuditor)
 

--- a/internal/manager/keyconfiguration_test.go
+++ b/internal/manager/keyconfiguration_test.go
@@ -101,7 +101,8 @@ func SetupKeyConfigManager(t *testing.T) (*manager.KeyConfigManager, *multitenan
 	authzRepo := authz_repo.NewAuthzRepo(r, authzRepoLoader)
 
 	userManager := manager.NewUserManager(authzRepo, cmkAuditor)
-	tagManager := manager.NewTagManager(authzRepo)
+	resourceLabelManager := manager.NewResourceLabelManager(authzRepo)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 
 	eventFactory, err := eventprocessor.NewEventFactory(t.Context(), cfg, r)
 	assert.NoError(t, err)
@@ -1016,12 +1017,13 @@ func TestDeleteKeyConfiguration(t *testing.T) {
 	ctx = testutils.InjectBusinessUserDataIntoContext(ctx, uuid.NewString(), []string{expected.AdminGroup.IAMIdentifier})
 	ctx = cmkcontext.InjectRequestID(ctx, uuid.NewString())
 
-	bytes, err := json.Marshal(&[]string{"tag1"})
-	assert.NoError(t, err)
-	tags := testutils.NewTag(func(t *model.Tag) {
-		t.ID = expected.ID
-		t.Values = bytes
-	})
+	tags := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKeyConfig,
+		ResourceID:   expected.ID,
+		Key:          model.SystemTagKey,
+		Value:        "tag1",
+	}
 
 	testutils.CreateTestEntities(ctx, t, r, expected, tags, adminGroup, keyConfigWithAdminGroup)
 
@@ -1043,7 +1045,11 @@ func TestDeleteKeyConfiguration(t *testing.T) {
 		assert.Equal(t, 0, count)
 		assert.NoError(t, err)
 
-		count, err = r.Count(ctx, &model.Tag{ID: expected.ID}, *repo.NewQuery())
+		ck := repo.NewCompositeKey().
+			Where(repo.ResourceTypeField, model.ResourceTypeKeyConfig).
+			Where(repo.ResourceIDField, expected.ID).
+			Where(repo.KeyField, model.SystemTagKey)
+		count, err = r.Count(ctx, &model.ResourceLabel{}, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
 		assert.Equal(t, 0, count)
 		assert.NoError(t, err)
 	})

--- a/internal/manager/keyversion_test.go
+++ b/internal/manager/keyversion_test.go
@@ -65,7 +65,8 @@ func (s *KeyVersionManagerSuit) SetupSuite() {
 	tenantConfigManager := manager.NewTenantConfigManager(s.r, svcRegistry, nil)
 	cmkAuditor := auditor.New(s.ctx, &cfg)
 	userManager := manager.NewUserManager(s.r, cmkAuditor)
-	tagManager := manager.NewTagManager(s.r)
+	resourceLabelManager := manager.NewResourceLabelManager(s.r)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 	keyConfigManager := manager.NewKeyConfigManager(s.r, certManager, userManager, tagManager, cmkAuditor, nil, &cfg)
 	s.km = manager.NewKeyManager(s.r, svcRegistry, tenantConfigManager, keyConfigManager, userManager, certManager, nil, cmkAuditor)
 	s.kvm = manager.NewKeyVersionManager(

--- a/internal/manager/resource_label.go
+++ b/internal/manager/resource_label.go
@@ -1,0 +1,256 @@
+package manager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/google/uuid"
+
+	"github.com/openkcm/cmk/internal/errs"
+	"github.com/openkcm/cmk/internal/model"
+	"github.com/openkcm/cmk/internal/repo"
+)
+
+// ResourceLabels defines operations for managing labels and tags across different resource types
+type ResourceLabels interface {
+	// Label operations - manage key-value pairs (excludes system tags)
+	GetLabels(ctx context.Context, resourceType model.ResourceType, resourceID uuid.UUID, pagination repo.Pagination) ([]*model.ResourceLabel, int, error)
+	CreateOrUpdateLabels(ctx context.Context, resourceType model.ResourceType, resourceID uuid.UUID, labels []*model.ResourceLabel) error
+	DeleteLabel(ctx context.Context, resourceType model.ResourceType, resourceID uuid.UUID, labelKey string) (bool, error)
+
+	// Tag operations - manage tags as special labels with key="system.tag"
+	GetTags(ctx context.Context, resourceType model.ResourceType, resourceID uuid.UUID) ([]string, error)
+	SetTags(ctx context.Context, resourceType model.ResourceType, resourceID uuid.UUID, tags []string) error
+	DeleteTags(ctx context.Context, resourceType model.ResourceType, resourceID uuid.UUID) error
+}
+
+// ResourceLabelManager implements the ResourceLabels interface
+type ResourceLabelManager struct {
+	r repo.Repo
+}
+
+// NewResourceLabelManager creates a new ResourceLabelManager
+func NewResourceLabelManager(r repo.Repo) *ResourceLabelManager {
+	return &ResourceLabelManager{r: r}
+}
+
+// GetLabels retrieves all labels for a resource (excluding system tags)
+func (m *ResourceLabelManager) GetLabels(
+	ctx context.Context,
+	resourceType model.ResourceType,
+	resourceID uuid.UUID,
+	pagination repo.Pagination,
+) ([]*model.ResourceLabel, int, error) {
+	// Build composite key to filter by resource type and resource ID
+	ck := repo.NewCompositeKey().
+		Where(repo.ResourceTypeField, resourceType).
+		Where(repo.ResourceIDField, resourceID).
+		Where(repo.KeyField, model.SystemTagKey, repo.NotEq)
+
+	query := repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck))
+
+	labels, count, err := repo.ListAndCount(ctx, m.r, pagination, model.ResourceLabel{}, query)
+	if err != nil {
+		return nil, 0, errs.Wrap(ErrQueryLabelList, err)
+	}
+
+	return labels, count, nil
+}
+
+// CreateOrUpdateLabels creates or updates multiple labels for a resource
+func (m *ResourceLabelManager) CreateOrUpdateLabels(
+	ctx context.Context,
+	resourceType model.ResourceType,
+	resourceID uuid.UUID,
+	labels []*model.ResourceLabel,
+) error {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	return m.r.Transaction(ctx, func(ctx context.Context) error {
+		for _, label := range labels {
+			// Ensure the label has correct resource type and ID
+			label.ResourceType = resourceType
+			label.ResourceID = resourceID
+
+			// Check if label already exists
+			ck := repo.NewCompositeKey().
+				Where(repo.ResourceTypeField, resourceType).
+				Where(repo.ResourceIDField, resourceID).
+				Where(repo.KeyField, label.Key).
+				Where(repo.ValueField, label.Value)
+
+			existing := &model.ResourceLabel{}
+			found, err := m.r.First(ctx, existing, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
+			if err != nil && !errors.Is(err, repo.ErrNotFound) {
+				return errs.Wrap(ErrFetchLabel, err)
+			}
+
+			if found {
+				// Label already exists with same value, skip
+				continue
+			}
+
+			// Check if a label with same key but different value exists
+			ck = repo.NewCompositeKey().
+				Where(repo.ResourceTypeField, resourceType).
+				Where(repo.ResourceIDField, resourceID).
+				Where(repo.KeyField, label.Key)
+
+			found, err = m.r.First(ctx, existing, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
+			if err != nil && !errors.Is(err, repo.ErrNotFound) {
+				return errs.Wrap(ErrFetchLabel, err)
+			}
+
+			if found {
+				// Update existing label with new value
+				existing.Value = label.Value
+
+				_, err = m.r.Patch(ctx, existing, *repo.NewQuery().UpdateAll(true))
+				if err != nil {
+					return errs.Wrap(ErrUpdateLabelDB, err)
+				}
+			} else {
+				// Create new label
+				label.ID = uuid.New()
+				err = m.r.Create(ctx, label)
+				if err != nil {
+					return errs.Wrap(ErrInsertLabel, err)
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// DeleteLabel removes a single label by key
+func (m *ResourceLabelManager) DeleteLabel(
+	ctx context.Context,
+	resourceType model.ResourceType,
+	resourceID uuid.UUID,
+	labelKey string,
+) (bool, error) {
+	ck := repo.NewCompositeKey().
+		Where(repo.ResourceTypeField, resourceType).
+		Where(repo.ResourceIDField, resourceID).
+		Where(repo.KeyField, labelKey)
+
+	query := repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck))
+
+	deleted, err := m.r.Delete(ctx, &model.ResourceLabel{}, *query)
+	if err != nil {
+		return false, errs.Wrap(ErrDeleteLabelDB, err)
+	}
+
+	return deleted, nil
+}
+
+// GetTags retrieves all tag values for a resource
+func (m *ResourceLabelManager) GetTags(
+	ctx context.Context,
+	resourceType model.ResourceType,
+	resourceID uuid.UUID,
+) ([]string, error) {
+	// Query all labels with key="system.tag"
+	ck := repo.NewCompositeKey().
+		Where(repo.ResourceTypeField, resourceType).
+		Where(repo.ResourceIDField, resourceID).
+		Where(repo.KeyField, model.SystemTagKey)
+
+	query := repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck))
+
+	labels := []*model.ResourceLabel{}
+	err := m.r.List(ctx, &model.ResourceLabel{}, &labels, *query)
+	if err != nil {
+		return nil, errs.Wrap(ErrGetTags, err)
+	}
+
+	// Extract tag values
+	tags := make([]string, 0, len(labels))
+	for _, label := range labels {
+		tags = append(tags, label.Value)
+	}
+
+	return tags, nil
+}
+
+// SetTags replaces all tags for a resource
+func (m *ResourceLabelManager) SetTags(
+	ctx context.Context,
+	resourceType model.ResourceType,
+	resourceID uuid.UUID,
+	tags []string,
+) error {
+	// Special case: single empty string triggers deletion (backwards compatibility)
+	if len(tags) == 1 && tags[0] == "" {
+		return m.DeleteTags(ctx, resourceType, resourceID)
+	}
+
+	return m.r.Transaction(ctx, func(ctx context.Context) error {
+		// Delete existing tags first
+		ck := repo.NewCompositeKey().
+			Where(repo.ResourceTypeField, resourceType).
+			Where(repo.ResourceIDField, resourceID).
+			Where(repo.KeyField, model.SystemTagKey)
+
+		query := repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck))
+		_, err := m.r.Delete(ctx, &model.ResourceLabel{}, *query)
+		if err != nil {
+			return errs.Wrap(ErrDeletingTags, err)
+		}
+
+		// Create new tags
+		for _, tag := range tags {
+			if tag == "" {
+				continue // Skip empty tags
+			}
+
+			label := &model.ResourceLabel{
+				ID:           uuid.New(),
+				ResourceType: resourceType,
+				ResourceID:   resourceID,
+				Key:          model.SystemTagKey,
+				Value:        tag,
+			}
+
+			err = m.r.Create(ctx, label)
+			if err != nil {
+				return errs.Wrap(ErrCreateTag, err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// DeleteTags removes all tags for a resource
+func (m *ResourceLabelManager) DeleteTags(
+	ctx context.Context,
+	resourceType model.ResourceType,
+	resourceID uuid.UUID,
+) error {
+	ck := repo.NewCompositeKey().
+		Where(repo.ResourceTypeField, resourceType).
+		Where(repo.ResourceIDField, resourceID).
+		Where(repo.KeyField, model.SystemTagKey)
+
+	query := repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck))
+
+	_, err := m.r.Delete(ctx, &model.ResourceLabel{}, *query)
+	if err != nil {
+		return errs.Wrap(ErrDeletingTags, err)
+	}
+
+	return nil
+}
+
+// Helper to marshal tags to JSON (for backwards compatibility if needed)
+func marshalTags(tags []string) (json.RawMessage, error) {
+	bytes, err := json.Marshal(tags)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(bytes), nil
+}

--- a/internal/manager/resource_label.go
+++ b/internal/manager/resource_label.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 
 	"github.com/google/uuid"
@@ -15,9 +14,24 @@ import (
 // ResourceLabels defines operations for managing labels and tags across different resource types
 type ResourceLabels interface {
 	// Label operations - manage key-value pairs (excludes system tags)
-	GetLabels(ctx context.Context, resourceType model.ResourceType, resourceID uuid.UUID, pagination repo.Pagination) ([]*model.ResourceLabel, int, error)
-	CreateOrUpdateLabels(ctx context.Context, resourceType model.ResourceType, resourceID uuid.UUID, labels []*model.ResourceLabel) error
-	DeleteLabel(ctx context.Context, resourceType model.ResourceType, resourceID uuid.UUID, labelKey string) (bool, error)
+	GetLabels(
+		ctx context.Context,
+		resourceType model.ResourceType,
+		resourceID uuid.UUID,
+		pagination repo.Pagination,
+	) ([]*model.ResourceLabel, int, error)
+	CreateOrUpdateLabels(
+		ctx context.Context,
+		resourceType model.ResourceType,
+		resourceID uuid.UUID,
+		labels []*model.ResourceLabel,
+	) error
+	DeleteLabel(
+		ctx context.Context,
+		resourceType model.ResourceType,
+		resourceID uuid.UUID,
+		labelKey string,
+	) (bool, error)
 
 	// Tag operations - manage tags as special labels with key="system.tag"
 	GetTags(ctx context.Context, resourceType model.ResourceType, resourceID uuid.UUID) ([]string, error)
@@ -75,54 +89,90 @@ func (m *ResourceLabelManager) CreateOrUpdateLabels(
 			label.ResourceType = resourceType
 			label.ResourceID = resourceID
 
-			// Check if label already exists
-			ck := repo.NewCompositeKey().
-				Where(repo.ResourceTypeField, resourceType).
-				Where(repo.ResourceIDField, resourceID).
-				Where(repo.KeyField, label.Key).
-				Where(repo.ValueField, label.Value)
-
-			existing := &model.ResourceLabel{}
-			found, err := m.r.First(ctx, existing, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
-			if err != nil && !errors.Is(err, repo.ErrNotFound) {
-				return errs.Wrap(ErrFetchLabel, err)
-			}
-
-			if found {
-				// Label already exists with same value, skip
-				continue
-			}
-
-			// Check if a label with same key but different value exists
-			ck = repo.NewCompositeKey().
-				Where(repo.ResourceTypeField, resourceType).
-				Where(repo.ResourceIDField, resourceID).
-				Where(repo.KeyField, label.Key)
-
-			found, err = m.r.First(ctx, existing, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
-			if err != nil && !errors.Is(err, repo.ErrNotFound) {
-				return errs.Wrap(ErrFetchLabel, err)
-			}
-
-			if found {
-				// Update existing label with new value
-				existing.Value = label.Value
-
-				_, err = m.r.Patch(ctx, existing, *repo.NewQuery().UpdateAll(true))
-				if err != nil {
-					return errs.Wrap(ErrUpdateLabelDB, err)
-				}
-			} else {
-				// Create new label
-				label.ID = uuid.New()
-				err = m.r.Create(ctx, label)
-				if err != nil {
-					return errs.Wrap(ErrInsertLabel, err)
-				}
+			if err := m.upsertLabel(ctx, label); err != nil {
+				return err
 			}
 		}
 		return nil
 	})
+}
+
+// upsertLabel creates or updates a single label
+func (m *ResourceLabelManager) upsertLabel(ctx context.Context, label *model.ResourceLabel) error {
+	// Check if label already exists with same value
+	existing, found, err := m.findExactLabel(ctx, label)
+	if err != nil {
+		return errs.Wrap(ErrFetchLabel, err)
+	}
+
+	if found {
+		// Label already exists with same value, skip
+		return nil
+	}
+
+	// Check if a label with same key but different value exists
+	existing, found, err = m.findLabelByKey(ctx, label.ResourceType, label.ResourceID, label.Key)
+	if err != nil {
+		return errs.Wrap(ErrFetchLabel, err)
+	}
+
+	if found {
+		// Update existing label with new value
+		existing.Value = label.Value
+		_, err = m.r.Patch(ctx, existing, *repo.NewQuery().UpdateAll(true))
+		if err != nil {
+			return errs.Wrap(ErrUpdateLabelDB, err)
+		}
+		return nil
+	}
+
+	// Create new label
+	label.ID = uuid.New()
+	if err := m.r.Create(ctx, label); err != nil {
+		return errs.Wrap(ErrInsertLabel, err)
+	}
+	return nil
+}
+
+// findExactLabel finds a label with exact resource type, ID, key, and value match
+func (m *ResourceLabelManager) findExactLabel(
+	ctx context.Context,
+	label *model.ResourceLabel,
+) (*model.ResourceLabel, bool, error) {
+	ck := repo.NewCompositeKey().
+		Where(repo.ResourceTypeField, label.ResourceType).
+		Where(repo.ResourceIDField, label.ResourceID).
+		Where(repo.KeyField, label.Key).
+		Where(repo.ValueField, label.Value)
+
+	existing := &model.ResourceLabel{}
+	found, err := m.r.First(ctx, existing, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
+	if err != nil && !errors.Is(err, repo.ErrNotFound) {
+		return nil, false, err
+	}
+
+	return existing, found, nil
+}
+
+// findLabelByKey finds a label with matching resource type, ID, and key
+func (m *ResourceLabelManager) findLabelByKey(
+	ctx context.Context,
+	resourceType model.ResourceType,
+	resourceID uuid.UUID,
+	key string,
+) (*model.ResourceLabel, bool, error) {
+	ck := repo.NewCompositeKey().
+		Where(repo.ResourceTypeField, resourceType).
+		Where(repo.ResourceIDField, resourceID).
+		Where(repo.KeyField, key)
+
+	existing := &model.ResourceLabel{}
+	found, err := m.r.First(ctx, existing, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
+	if err != nil && !errors.Is(err, repo.ErrNotFound) {
+		return nil, false, err
+	}
+
+	return existing, found, nil
 }
 
 // DeleteLabel removes a single label by key
@@ -244,13 +294,4 @@ func (m *ResourceLabelManager) DeleteTags(
 	}
 
 	return nil
-}
-
-// Helper to marshal tags to JSON (for backwards compatibility if needed)
-func marshalTags(tags []string) (json.RawMessage, error) {
-	bytes, err := json.Marshal(tags)
-	if err != nil {
-		return nil, err
-	}
-	return json.RawMessage(bytes), nil
 }

--- a/internal/manager/resource_label.go
+++ b/internal/manager/resource_label.go
@@ -97,84 +97,6 @@ func (m *ResourceLabelManager) CreateOrUpdateLabels(
 	})
 }
 
-// upsertLabel creates or updates a single label
-func (m *ResourceLabelManager) upsertLabel(ctx context.Context, label *model.ResourceLabel) error {
-	// Check if label already exists with same value
-	existing, found, err := m.findExactLabel(ctx, label)
-	if err != nil {
-		return errs.Wrap(ErrFetchLabel, err)
-	}
-
-	if found {
-		// Label already exists with same value, skip
-		return nil
-	}
-
-	// Check if a label with same key but different value exists
-	existing, found, err = m.findLabelByKey(ctx, label.ResourceType, label.ResourceID, label.Key)
-	if err != nil {
-		return errs.Wrap(ErrFetchLabel, err)
-	}
-
-	if found {
-		// Update existing label with new value
-		existing.Value = label.Value
-		_, err = m.r.Patch(ctx, existing, *repo.NewQuery().UpdateAll(true))
-		if err != nil {
-			return errs.Wrap(ErrUpdateLabelDB, err)
-		}
-		return nil
-	}
-
-	// Create new label
-	label.ID = uuid.New()
-	if err := m.r.Create(ctx, label); err != nil {
-		return errs.Wrap(ErrInsertLabel, err)
-	}
-	return nil
-}
-
-// findExactLabel finds a label with exact resource type, ID, key, and value match
-func (m *ResourceLabelManager) findExactLabel(
-	ctx context.Context,
-	label *model.ResourceLabel,
-) (*model.ResourceLabel, bool, error) {
-	ck := repo.NewCompositeKey().
-		Where(repo.ResourceTypeField, label.ResourceType).
-		Where(repo.ResourceIDField, label.ResourceID).
-		Where(repo.KeyField, label.Key).
-		Where(repo.ValueField, label.Value)
-
-	existing := &model.ResourceLabel{}
-	found, err := m.r.First(ctx, existing, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
-	if err != nil && !errors.Is(err, repo.ErrNotFound) {
-		return nil, false, err
-	}
-
-	return existing, found, nil
-}
-
-// findLabelByKey finds a label with matching resource type, ID, and key
-func (m *ResourceLabelManager) findLabelByKey(
-	ctx context.Context,
-	resourceType model.ResourceType,
-	resourceID uuid.UUID,
-	key string,
-) (*model.ResourceLabel, bool, error) {
-	ck := repo.NewCompositeKey().
-		Where(repo.ResourceTypeField, resourceType).
-		Where(repo.ResourceIDField, resourceID).
-		Where(repo.KeyField, key)
-
-	existing := &model.ResourceLabel{}
-	found, err := m.r.First(ctx, existing, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
-	if err != nil && !errors.Is(err, repo.ErrNotFound) {
-		return nil, false, err
-	}
-
-	return existing, found, nil
-}
-
 // DeleteLabel removes a single label by key
 func (m *ResourceLabelManager) DeleteLabel(
 	ctx context.Context,
@@ -294,4 +216,82 @@ func (m *ResourceLabelManager) DeleteTags(
 	}
 
 	return nil
+}
+
+// upsertLabel creates or updates a single label
+func (m *ResourceLabelManager) upsertLabel(ctx context.Context, label *model.ResourceLabel) error {
+	// Check if label already exists with same value
+	_, found, err := m.findExactLabel(ctx, label)
+	if err != nil {
+		return errs.Wrap(ErrFetchLabel, err)
+	}
+
+	if found {
+		// Label already exists with same value, skip
+		return nil
+	}
+
+	// Check if a label with same key but different value exists
+	existing, found, err := m.findLabelByKey(ctx, label.ResourceType, label.ResourceID, label.Key)
+	if err != nil {
+		return errs.Wrap(ErrFetchLabel, err)
+	}
+
+	if found {
+		// Update existing label with new value
+		existing.Value = label.Value
+		_, err = m.r.Patch(ctx, existing, *repo.NewQuery().UpdateAll(true))
+		if err != nil {
+			return errs.Wrap(ErrUpdateLabelDB, err)
+		}
+		return nil
+	}
+
+	// Create new label
+	label.ID = uuid.New()
+	if err := m.r.Create(ctx, label); err != nil {
+		return errs.Wrap(ErrInsertLabel, err)
+	}
+	return nil
+}
+
+// findExactLabel finds a label with exact resource type, ID, key, and value match
+func (m *ResourceLabelManager) findExactLabel(
+	ctx context.Context,
+	label *model.ResourceLabel,
+) (*model.ResourceLabel, bool, error) {
+	ck := repo.NewCompositeKey().
+		Where(repo.ResourceTypeField, label.ResourceType).
+		Where(repo.ResourceIDField, label.ResourceID).
+		Where(repo.KeyField, label.Key).
+		Where(repo.ValueField, label.Value)
+
+	existing := &model.ResourceLabel{}
+	found, err := m.r.First(ctx, existing, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
+	if err != nil && !errors.Is(err, repo.ErrNotFound) {
+		return nil, false, err
+	}
+
+	return existing, found, nil
+}
+
+// findLabelByKey finds a label with matching resource type, ID, and key
+func (m *ResourceLabelManager) findLabelByKey(
+	ctx context.Context,
+	resourceType model.ResourceType,
+	resourceID uuid.UUID,
+	key string,
+) (*model.ResourceLabel, bool, error) {
+	ck := repo.NewCompositeKey().
+		Where(repo.ResourceTypeField, resourceType).
+		Where(repo.ResourceIDField, resourceID).
+		Where(repo.KeyField, key)
+
+	existing := &model.ResourceLabel{}
+	found, err := m.r.First(ctx, existing, *repo.NewQuery().Where(repo.NewCompositeKeyGroup(ck)))
+	if err != nil && !errors.Is(err, repo.ErrNotFound) {
+		return nil, false, err
+	}
+
+	return existing, found, nil
 }

--- a/internal/manager/resource_label_test.go
+++ b/internal/manager/resource_label_test.go
@@ -187,7 +187,7 @@ func TestCreateOrUpdateLabels(t *testing.T) {
 		retrieved, count, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{Count: true})
 		require.NoError(t, err)
 		assert.Equal(t, 2, count)
-		assert.Equal(t, 2, len(retrieved))
+		assert.Len(t, retrieved, 2)
 	})
 
 	t.Run("Should handle empty label slice", func(t *testing.T) {
@@ -211,7 +211,7 @@ func TestCreateOrUpdateLabels(t *testing.T) {
 		// Verify it exists
 		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKey, newResourceID, repo.Pagination{})
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(labels))
+		assert.Len(t, labels, 1)
 	})
 }
 
@@ -249,7 +249,7 @@ func TestDeleteLabel(t *testing.T) {
 		// Verify label was deleted
 		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{})
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(labels))
+		assert.Len(t, labels, 1)
 		assert.Equal(t, "region", labels[0].Key)
 	})
 
@@ -267,7 +267,7 @@ func TestDeleteLabel(t *testing.T) {
 		// Verify original label still exists
 		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{})
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(labels))
+		assert.Len(t, labels, 1)
 	})
 }
 
@@ -308,7 +308,7 @@ func TestGetTags(t *testing.T) {
 	t.Run("Should get tags as string array", func(t *testing.T) {
 		tags, err := m.GetTags(ctx, model.ResourceTypeKeyConfig, resourceID)
 		require.NoError(t, err)
-		assert.Equal(t, 2, len(tags))
+		assert.Len(t, tags, 2)
 		assert.Contains(t, tags, "EU")
 		assert.Contains(t, tags, "TEST")
 	})
@@ -367,7 +367,7 @@ func TestSetTags(t *testing.T) {
 
 		retrieved, err := m.GetTags(ctx, model.ResourceTypeKeyConfig, newResourceID)
 		require.NoError(t, err)
-		assert.Equal(t, 2, len(retrieved))
+		assert.Len(t, retrieved, 2)
 		assert.Contains(t, retrieved, "VALID")
 		assert.Contains(t, retrieved, "ALSO_VALID")
 	})
@@ -408,7 +408,7 @@ func TestSetTags(t *testing.T) {
 		// Verify label still exists
 		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKeyConfig, newResourceID, repo.Pagination{})
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(labels))
+		assert.Len(t, labels, 1)
 		assert.Equal(t, "environment", labels[0].Key)
 	})
 }
@@ -461,7 +461,7 @@ func TestDeleteTags(t *testing.T) {
 		// Verify label still exists
 		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKeyConfig, resourceID, repo.Pagination{})
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(labels))
+		assert.Len(t, labels, 1)
 		assert.Equal(t, "environment", labels[0].Key)
 	})
 
@@ -503,13 +503,13 @@ func TestResourceTypeIsolation(t *testing.T) {
 		// Get KEY labels
 		keyLabels, _, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{})
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(keyLabels))
+		assert.Len(t, keyLabels, 1)
 		assert.Equal(t, "key-label", keyLabels[0].Key)
 
 		// Get KEY_CONFIG labels
 		configLabels, _, err := m.GetLabels(ctx, model.ResourceTypeKeyConfig, resourceID, repo.Pagination{})
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(configLabels))
+		assert.Len(t, configLabels, 1)
 		assert.Equal(t, "config-label", configLabels[0].Key)
 	})
 
@@ -522,6 +522,6 @@ func TestResourceTypeIsolation(t *testing.T) {
 		// Verify KEY_CONFIG label still exists
 		configLabels, _, err := m.GetLabels(ctx, model.ResourceTypeKeyConfig, resourceID, repo.Pagination{})
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(configLabels))
+		assert.Len(t, configLabels, 1)
 	})
 }

--- a/internal/manager/resource_label_test.go
+++ b/internal/manager/resource_label_test.go
@@ -1,0 +1,527 @@
+package manager_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	multitenancy "github.com/bartventer/gorm-multitenancy/v8"
+
+	"github.com/openkcm/cmk/internal/manager"
+	"github.com/openkcm/cmk/internal/model"
+	"github.com/openkcm/cmk/internal/repo"
+	"github.com/openkcm/cmk/internal/repo/sql"
+	"github.com/openkcm/cmk/internal/testutils"
+	cmkcontext "github.com/openkcm/cmk/utils/context"
+)
+
+func setupResourceLabelManager(t *testing.T) (*manager.ResourceLabelManager, *multitenancy.DB, string) {
+	t.Helper()
+
+	db, tenants, _ := testutils.NewTestDB(t, testutils.TestDBConfig{})
+	dbRepository := sql.NewRepository(db)
+	resourceLabelManager := manager.NewResourceLabelManager(dbRepository)
+
+	return resourceLabelManager, db, tenants[0]
+}
+
+// TestGetLabels tests retrieving labels for a resource
+func TestGetLabels(t *testing.T) {
+	m, db, tenant := setupResourceLabelManager(t)
+	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
+	r := sql.NewRepository(db)
+
+	resourceID := uuid.New()
+
+	// Create test labels
+	label1 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKey,
+		ResourceID:   resourceID,
+		Key:          "environment",
+		Value:        "production",
+	}
+	label2 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKey,
+		ResourceID:   resourceID,
+		Key:          "region",
+		Value:        "eu-west-1",
+	}
+	// Create a system tag (should be excluded from labels)
+	tag := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKey,
+		ResourceID:   resourceID,
+		Key:          model.SystemTagKey,
+		Value:        "test-tag",
+	}
+	// Create label for different resource (should not be returned)
+	otherLabel := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKey,
+		ResourceID:   uuid.New(),
+		Key:          "other",
+		Value:        "other",
+	}
+
+	testutils.CreateTestEntities(ctx, t, r, label1, label2, tag, otherLabel)
+
+	t.Run("Should get labels excluding system tags", func(t *testing.T) {
+		labels, count, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{Count: true})
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(labels))
+		assert.Equal(t, 2, count)
+
+		// Verify labels are returned
+		foundEnv := false
+		foundRegion := false
+		for _, label := range labels {
+			assert.Equal(t, resourceID, label.ResourceID)
+			assert.NotEqual(t, model.SystemTagKey, label.Key)
+			if label.Key == "environment" {
+				foundEnv = true
+				assert.Equal(t, "production", label.Value)
+			}
+			if label.Key == "region" {
+				foundRegion = true
+				assert.Equal(t, "eu-west-1", label.Value)
+			}
+		}
+		assert.True(t, foundEnv)
+		assert.True(t, foundRegion)
+	})
+
+	t.Run("Should return empty for non-existing resource", func(t *testing.T) {
+		labels, count, err := m.GetLabels(ctx, model.ResourceTypeKey, uuid.New(), repo.Pagination{Count: true})
+		require.NoError(t, err)
+		assert.Empty(t, labels)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("Should support pagination", func(t *testing.T) {
+		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{
+			Top:  1,
+			Skip: 0,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(labels))
+	})
+
+	t.Run("Should filter by resource type", func(t *testing.T) {
+		// Query with wrong resource type
+		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKeyConfig, resourceID, repo.Pagination{})
+		require.NoError(t, err)
+		assert.Empty(t, labels)
+	})
+}
+
+// TestCreateOrUpdateLabels tests creating and updating labels
+func TestCreateOrUpdateLabels(t *testing.T) {
+	m, _, tenant := setupResourceLabelManager(t)
+	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
+
+	resourceID := uuid.New()
+
+	t.Run("Should create new labels", func(t *testing.T) {
+		labels := []*model.ResourceLabel{
+			{
+				Key:   "environment",
+				Value: "production",
+			},
+			{
+				Key:   "region",
+				Value: "eu-west-1",
+			},
+		}
+
+		err := m.CreateOrUpdateLabels(ctx, model.ResourceTypeKey, resourceID, labels)
+		require.NoError(t, err)
+
+		// Verify labels were created
+		retrieved, _, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{})
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(retrieved))
+	})
+
+	t.Run("Should update existing label value", func(t *testing.T) {
+		// Update environment label
+		labels := []*model.ResourceLabel{
+			{
+				Key:   "environment",
+				Value: "staging",
+			},
+		}
+
+		err := m.CreateOrUpdateLabels(ctx, model.ResourceTypeKey, resourceID, labels)
+		require.NoError(t, err)
+
+		// Verify label was updated
+		retrieved, _, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{})
+		require.NoError(t, err)
+
+		found := false
+		for _, label := range retrieved {
+			if label.Key == "environment" {
+				found = true
+				assert.Equal(t, "staging", label.Value)
+			}
+		}
+		assert.True(t, found)
+	})
+
+	t.Run("Should not create duplicate labels", func(t *testing.T) {
+		labels := []*model.ResourceLabel{
+			{
+				Key:   "region",
+				Value: "eu-west-1",
+			},
+		}
+
+		err := m.CreateOrUpdateLabels(ctx, model.ResourceTypeKey, resourceID, labels)
+		require.NoError(t, err)
+
+		// Verify no duplicates
+		retrieved, count, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{Count: true})
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+		assert.Equal(t, 2, len(retrieved))
+	})
+
+	t.Run("Should handle empty label slice", func(t *testing.T) {
+		err := m.CreateOrUpdateLabels(ctx, model.ResourceTypeKey, uuid.New(), []*model.ResourceLabel{})
+		require.NoError(t, err)
+	})
+
+	t.Run("Should rollback on error in transaction", func(t *testing.T) {
+		newResourceID := uuid.New()
+
+		// First create a valid label
+		validLabel := []*model.ResourceLabel{
+			{
+				Key:   "test",
+				Value: "value",
+			},
+		}
+		err := m.CreateOrUpdateLabels(ctx, model.ResourceTypeKey, newResourceID, validLabel)
+		require.NoError(t, err)
+
+		// Verify it exists
+		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKey, newResourceID, repo.Pagination{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(labels))
+	})
+}
+
+// TestDeleteLabel tests deleting a single label
+func TestDeleteLabel(t *testing.T) {
+	m, db, tenant := setupResourceLabelManager(t)
+	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
+	r := sql.NewRepository(db)
+
+	resourceID := uuid.New()
+
+	// Create test labels
+	label1 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKey,
+		ResourceID:   resourceID,
+		Key:          "environment",
+		Value:        "production",
+	}
+	label2 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKey,
+		ResourceID:   resourceID,
+		Key:          "region",
+		Value:        "eu-west-1",
+	}
+
+	testutils.CreateTestEntities(ctx, t, r, label1, label2)
+
+	t.Run("Should delete label by key", func(t *testing.T) {
+		deleted, err := m.DeleteLabel(ctx, model.ResourceTypeKey, resourceID, "environment")
+		require.NoError(t, err)
+		assert.True(t, deleted)
+
+		// Verify label was deleted
+		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(labels))
+		assert.Equal(t, "region", labels[0].Key)
+	})
+
+	t.Run("Should return false for non-existing label", func(t *testing.T) {
+		deleted, err := m.DeleteLabel(ctx, model.ResourceTypeKey, resourceID, "non-existing")
+		require.NoError(t, err)
+		assert.False(t, deleted)
+	})
+
+	t.Run("Should not delete labels from different resource", func(t *testing.T) {
+		deleted, err := m.DeleteLabel(ctx, model.ResourceTypeKey, uuid.New(), "region")
+		require.NoError(t, err)
+		assert.False(t, deleted)
+
+		// Verify original label still exists
+		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(labels))
+	})
+}
+
+// TestGetTags tests retrieving tags for a resource
+func TestGetTags(t *testing.T) {
+	m, db, tenant := setupResourceLabelManager(t)
+	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
+	r := sql.NewRepository(db)
+
+	resourceID := uuid.New()
+
+	// Create test tags
+	tag1 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKeyConfig,
+		ResourceID:   resourceID,
+		Key:          model.SystemTagKey,
+		Value:        "EU",
+	}
+	tag2 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKeyConfig,
+		ResourceID:   resourceID,
+		Key:          model.SystemTagKey,
+		Value:        "TEST",
+	}
+	// Create regular label (should not be returned as tag)
+	label := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKeyConfig,
+		ResourceID:   resourceID,
+		Key:          "environment",
+		Value:        "production",
+	}
+
+	testutils.CreateTestEntities(ctx, t, r, tag1, tag2, label)
+
+	t.Run("Should get tags as string array", func(t *testing.T) {
+		tags, err := m.GetTags(ctx, model.ResourceTypeKeyConfig, resourceID)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(tags))
+		assert.Contains(t, tags, "EU")
+		assert.Contains(t, tags, "TEST")
+	})
+
+	t.Run("Should return empty array for resource without tags", func(t *testing.T) {
+		tags, err := m.GetTags(ctx, model.ResourceTypeKeyConfig, uuid.New())
+		require.NoError(t, err)
+		assert.Empty(t, tags)
+	})
+
+	t.Run("Should filter by resource type", func(t *testing.T) {
+		// Query with wrong resource type
+		tags, err := m.GetTags(ctx, model.ResourceTypeKey, resourceID)
+		require.NoError(t, err)
+		assert.Empty(t, tags)
+	})
+}
+
+// TestSetTags tests replacing all tags for a resource
+func TestSetTags(t *testing.T) {
+	m, db, tenant := setupResourceLabelManager(t)
+	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
+	r := sql.NewRepository(db)
+
+	resourceID := uuid.New()
+
+	t.Run("Should set tags for new resource", func(t *testing.T) {
+		tags := []string{"EU", "TEST", "PRODUCTION"}
+		err := m.SetTags(ctx, model.ResourceTypeKeyConfig, resourceID, tags)
+		require.NoError(t, err)
+
+		// Verify tags were created
+		retrieved, err := m.GetTags(ctx, model.ResourceTypeKeyConfig, resourceID)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, tags, retrieved)
+	})
+
+	t.Run("Should replace existing tags", func(t *testing.T) {
+		newTags := []string{"US", "STAGING"}
+		err := m.SetTags(ctx, model.ResourceTypeKeyConfig, resourceID, newTags)
+		require.NoError(t, err)
+
+		// Verify old tags were replaced
+		retrieved, err := m.GetTags(ctx, model.ResourceTypeKeyConfig, resourceID)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, newTags, retrieved)
+		assert.NotContains(t, retrieved, "EU")
+		assert.NotContains(t, retrieved, "TEST")
+	})
+
+	t.Run("Should skip empty tag values", func(t *testing.T) {
+		newResourceID := uuid.New()
+		tags := []string{"VALID", "", "ALSO_VALID"}
+		err := m.SetTags(ctx, model.ResourceTypeKeyConfig, newResourceID, tags)
+		require.NoError(t, err)
+
+		retrieved, err := m.GetTags(ctx, model.ResourceTypeKeyConfig, newResourceID)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(retrieved))
+		assert.Contains(t, retrieved, "VALID")
+		assert.Contains(t, retrieved, "ALSO_VALID")
+	})
+
+	t.Run("Should delete tags when single empty string is provided", func(t *testing.T) {
+		// First set some tags
+		newResourceID := uuid.New()
+		err := m.SetTags(ctx, model.ResourceTypeKeyConfig, newResourceID, []string{"TAG1", "TAG2"})
+		require.NoError(t, err)
+
+		// Delete with single empty string (backwards compatibility)
+		err = m.SetTags(ctx, model.ResourceTypeKeyConfig, newResourceID, []string{""})
+		require.NoError(t, err)
+
+		// Verify tags were deleted
+		retrieved, err := m.GetTags(ctx, model.ResourceTypeKeyConfig, newResourceID)
+		require.NoError(t, err)
+		assert.Empty(t, retrieved)
+	})
+
+	t.Run("Should not affect regular labels", func(t *testing.T) {
+		newResourceID := uuid.New()
+
+		// Create a regular label
+		label := &model.ResourceLabel{
+			ID:           uuid.New(),
+			ResourceType: model.ResourceTypeKeyConfig,
+			ResourceID:   newResourceID,
+			Key:          "environment",
+			Value:        "production",
+		}
+		testutils.CreateTestEntities(ctx, t, r, label)
+
+		// Set tags
+		err := m.SetTags(ctx, model.ResourceTypeKeyConfig, newResourceID, []string{"TAG1"})
+		require.NoError(t, err)
+
+		// Verify label still exists
+		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKeyConfig, newResourceID, repo.Pagination{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(labels))
+		assert.Equal(t, "environment", labels[0].Key)
+	})
+}
+
+// TestDeleteTags tests removing all tags for a resource
+func TestDeleteTags(t *testing.T) {
+	m, db, tenant := setupResourceLabelManager(t)
+	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
+	r := sql.NewRepository(db)
+
+	resourceID := uuid.New()
+
+	// Create test tags
+	tag1 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKeyConfig,
+		ResourceID:   resourceID,
+		Key:          model.SystemTagKey,
+		Value:        "EU",
+	}
+	tag2 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKeyConfig,
+		ResourceID:   resourceID,
+		Key:          model.SystemTagKey,
+		Value:        "TEST",
+	}
+	// Create regular label (should not be deleted)
+	label := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKeyConfig,
+		ResourceID:   resourceID,
+		Key:          "environment",
+		Value:        "production",
+	}
+
+	testutils.CreateTestEntities(ctx, t, r, tag1, tag2, label)
+
+	t.Run("Should delete all tags", func(t *testing.T) {
+		err := m.DeleteTags(ctx, model.ResourceTypeKeyConfig, resourceID)
+		require.NoError(t, err)
+
+		// Verify tags were deleted
+		tags, err := m.GetTags(ctx, model.ResourceTypeKeyConfig, resourceID)
+		require.NoError(t, err)
+		assert.Empty(t, tags)
+	})
+
+	t.Run("Should not delete regular labels", func(t *testing.T) {
+		// Verify label still exists
+		labels, _, err := m.GetLabels(ctx, model.ResourceTypeKeyConfig, resourceID, repo.Pagination{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(labels))
+		assert.Equal(t, "environment", labels[0].Key)
+	})
+
+	t.Run("Should not error when deleting non-existing tags", func(t *testing.T) {
+		err := m.DeleteTags(ctx, model.ResourceTypeKeyConfig, uuid.New())
+		require.NoError(t, err)
+	})
+}
+
+// TestResourceTypeIsolation tests that operations on one resource type don't affect another
+func TestResourceTypeIsolation(t *testing.T) {
+	m, db, tenant := setupResourceLabelManager(t)
+	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
+	r := sql.NewRepository(db)
+
+	resourceID := uuid.New()
+
+	// Create labels for KEY resource type
+	keyLabel := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKey,
+		ResourceID:   resourceID,
+		Key:          "key-label",
+		Value:        "key-value",
+	}
+
+	// Create labels for KEY_CONFIG resource type
+	keyConfigLabel := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKeyConfig,
+		ResourceID:   resourceID,
+		Key:          "config-label",
+		Value:        "config-value",
+	}
+
+	testutils.CreateTestEntities(ctx, t, r, keyLabel, keyConfigLabel)
+
+	t.Run("Should isolate labels by resource type", func(t *testing.T) {
+		// Get KEY labels
+		keyLabels, _, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(keyLabels))
+		assert.Equal(t, "key-label", keyLabels[0].Key)
+
+		// Get KEY_CONFIG labels
+		configLabels, _, err := m.GetLabels(ctx, model.ResourceTypeKeyConfig, resourceID, repo.Pagination{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(configLabels))
+		assert.Equal(t, "config-label", configLabels[0].Key)
+	})
+
+	t.Run("Should isolate deletes by resource type", func(t *testing.T) {
+		// Delete KEY label
+		deleted, err := m.DeleteLabel(ctx, model.ResourceTypeKey, resourceID, "key-label")
+		require.NoError(t, err)
+		assert.True(t, deleted)
+
+		// Verify KEY_CONFIG label still exists
+		configLabels, _, err := m.GetLabels(ctx, model.ResourceTypeKeyConfig, resourceID, repo.Pagination{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(configLabels))
+	})
+}

--- a/internal/manager/resource_label_test.go
+++ b/internal/manager/resource_label_test.go
@@ -72,7 +72,7 @@ func TestGetLabels(t *testing.T) {
 	t.Run("Should get labels excluding system tags", func(t *testing.T) {
 		labels, count, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{Count: true})
 		require.NoError(t, err)
-		assert.Equal(t, 2, len(labels))
+		assert.Len(t, labels, 2)
 		assert.Equal(t, 2, count)
 
 		// Verify labels are returned
@@ -107,7 +107,7 @@ func TestGetLabels(t *testing.T) {
 			Skip: 0,
 		})
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(labels))
+		assert.Len(t, labels, 1)
 	})
 
 	t.Run("Should filter by resource type", func(t *testing.T) {
@@ -143,7 +143,7 @@ func TestCreateOrUpdateLabels(t *testing.T) {
 		// Verify labels were created
 		retrieved, _, err := m.GetLabels(ctx, model.ResourceTypeKey, resourceID, repo.Pagination{})
 		require.NoError(t, err)
-		assert.Equal(t, 2, len(retrieved))
+		assert.Len(t, retrieved, 2)
 	})
 
 	t.Run("Should update existing label value", func(t *testing.T) {

--- a/internal/manager/system_test.go
+++ b/internal/manager/system_test.go
@@ -75,7 +75,8 @@ func SetupSystemManager(t *testing.T, clientsFactory clients.Factory) (
 		},
 	)
 	userManager := manager.NewUserManager(r, auditor.New(t.Context(), &cfg))
-	tagManager := manager.NewTagManager(r)
+	resourceLabelManager := manager.NewResourceLabelManager(r)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 	keyConfigManager := manager.NewKeyConfigManager(r, certManager, userManager, tagManager, nil, nil, &cfg)
 
 	eventFactory, err := eventprocessor.NewEventFactory(t.Context(), &cfg, r)

--- a/internal/manager/tag.go
+++ b/internal/manager/tag.go
@@ -2,76 +2,44 @@ package manager
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 
 	"github.com/google/uuid"
 
-	"github.com/openkcm/cmk/internal/errs"
 	"github.com/openkcm/cmk/internal/model"
-	"github.com/openkcm/cmk/internal/repo"
 )
 
-var (
-	ErrGetKeyConfig = errors.New("error getting keyconfig")
-	ErrCreateTag    = errors.New("error setting tags")
-)
-
+// Tags interface for managing tags on resources (currently KeyConfigurations)
 type Tags interface {
 	SetTags(ctx context.Context, itemID uuid.UUID, values []string) error
 	GetTags(ctx context.Context, itemID uuid.UUID) ([]string, error)
 	DeleteTags(ctx context.Context, itemID uuid.UUID) error
 }
 
+// TagManager is an adapter that delegates to ResourceLabelManager
+// Maintains backward compatibility while using the new unified resource_labels table
 type TagManager struct {
-	r repo.Repo
+	resourceLabels ResourceLabels
 }
 
-func NewTagManager(r repo.Repo) *TagManager {
+// NewTagManager creates a new TagManager that uses ResourceLabelManager
+func NewTagManager(resourceLabels ResourceLabels) *TagManager {
 	return &TagManager{
-		r: r,
+		resourceLabels: resourceLabels,
 	}
 }
 
-func (m *TagManager) DeleteTags(ctx context.Context, itemID uuid.UUID) error {
-	_, err := m.r.Delete(ctx, &model.Tag{ID: itemID}, *repo.NewQuery())
-	if err != nil {
-		return errs.Wrap(ErrDeletingTags, err)
-	}
-
-	return nil
-}
-
+// SetTags sets tags for a key configuration
+// Tags are stored as labels with key="system.tag"
 func (m *TagManager) SetTags(ctx context.Context, itemID uuid.UUID, values []string) error {
-	if len(values) == 1 && values[0] == "" {
-		return m.DeleteTags(ctx, itemID)
-	}
-
-	bytes, err := json.Marshal(values)
-	if err != nil {
-		return err
-	}
-
-	return m.r.Set(ctx, &model.Tag{ID: itemID, Values: bytes})
+	return m.resourceLabels.SetTags(ctx, model.ResourceTypeKeyConfig, itemID, values)
 }
 
+// GetTags retrieves tags for a key configuration
 func (m *TagManager) GetTags(ctx context.Context, itemID uuid.UUID) ([]string, error) {
-	values := []string{}
-	tag := &model.Tag{ID: itemID}
-	_, err := m.r.First(ctx, tag, *repo.NewQuery())
+	return m.resourceLabels.GetTags(ctx, model.ResourceTypeKeyConfig, itemID)
+}
 
-	if errors.Is(err, repo.ErrNotFound) {
-		return values, nil
-	}
-
-	if !errors.Is(err, err) {
-		return nil, errs.Wrap(ErrGetTags, err)
-	}
-
-	err = json.Unmarshal(tag.Values, &values)
-	if err != nil {
-		return nil, err
-	}
-
-	return values, nil
+// DeleteTags removes all tags for a key configuration
+func (m *TagManager) DeleteTags(ctx context.Context, itemID uuid.UUID) error {
+	return m.resourceLabels.DeleteTags(ctx, model.ResourceTypeKeyConfig, itemID)
 }

--- a/internal/manager/tag_test.go
+++ b/internal/manager/tag_test.go
@@ -1,7 +1,6 @@
 package manager_test
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/google/uuid"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/openkcm/cmk/internal/manager"
 	"github.com/openkcm/cmk/internal/model"
-	"github.com/openkcm/cmk/internal/repo"
 	"github.com/openkcm/cmk/internal/repo/sql"
 	"github.com/openkcm/cmk/internal/testutils"
 	cmkcontext "github.com/openkcm/cmk/utils/context"
@@ -25,7 +23,8 @@ func SetupTagManager(t *testing.T) (*manager.TagManager,
 	db, tenants, _ := testutils.NewTestDB(t, testutils.TestDBConfig{})
 
 	dbRepository := sql.NewRepository(db)
-	tagManager := manager.NewTagManager(dbRepository)
+	resourceLabelManager := manager.NewResourceLabelManager(dbRepository)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 
 	return tagManager, db, tenants[0]
 }
@@ -36,22 +35,23 @@ func TestGetKeyConfigurationTags(t *testing.T) {
 	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
 	r := sql.NewRepository(db)
 
-	expectedTagValue := []string{"tag1"}
-	bytes, err := json.Marshal(expectedTagValue)
-	assert.NoError(t, err)
-
 	id := uuid.New()
-	tag := testutils.NewTag(func(t *model.Tag) {
-		t.ID = id
-		t.Values = bytes
-	})
 
-	testutils.CreateTestEntities(ctx, t, r, tag)
+	// Create tags using the new resource_labels format
+	tag1 := &model.ResourceLabel{
+		ID:           uuid.New(),
+		ResourceType: model.ResourceTypeKeyConfig,
+		ResourceID:   id,
+		Key:          model.SystemTagKey,
+		Value:        "tag1",
+	}
+
+	testutils.CreateTestEntities(ctx, t, r, tag1)
 
 	t.Run("Should get tags", func(t *testing.T) {
 		tags, err := m.GetTags(ctx, id)
 		assert.NoError(t, err)
-		assert.Equal(t, expectedTagValue, tags)
+		assert.Equal(t, []string{"tag1"}, tags)
 	})
 
 	t.Run("Should return empty on non existing tag", func(t *testing.T) {
@@ -62,9 +62,8 @@ func TestGetKeyConfigurationTags(t *testing.T) {
 }
 
 func TestCreateTags(t *testing.T) {
-	m, db, tenant := SetupTagManager(t)
+	m, _, tenant := SetupTagManager(t)
 	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
-	r := sql.NewRepository(db)
 
 	t.Run("Should set tags", func(t *testing.T) {
 		id := uuid.New()
@@ -72,24 +71,19 @@ func TestCreateTags(t *testing.T) {
 		err := m.SetTags(ctx, id, tags)
 		assert.NoError(t, err)
 
-		tag := &model.Tag{ID: id}
-		_, err = r.First(ctx, tag, *repo.NewQuery())
+		// Verify tags were created in resource_labels table
+		retrievedTags, err := m.GetTags(ctx, id)
 		assert.NoError(t, err)
+		assert.ElementsMatch(t, tags, retrievedTags)
 
-		res := []string{}
-		err = json.Unmarshal(tag.Values, &res)
-		assert.NoError(t, err)
-		assert.Equal(t, tags, res)
-
+		// Update tags
 		tags = []string{"tag3", "tag4"}
 		err = m.SetTags(ctx, id, tags)
 		assert.NoError(t, err)
-		_, err = r.First(ctx, tag, *repo.NewQuery())
-		assert.NoError(t, err)
 
-		err = json.Unmarshal(tag.Values, &res)
+		retrievedTags, err = m.GetTags(ctx, id)
 		assert.NoError(t, err)
-		assert.Equal(t, tags, res)
+		assert.ElementsMatch(t, tags, retrievedTags)
 	})
 
 	t.Run("Should not write empty tag", func(t *testing.T) {

--- a/internal/manager/tenant_test.go
+++ b/internal/manager/tenant_test.go
@@ -62,7 +62,8 @@ func SetupTenantManager(t *testing.T, opts ...testutils.TestDBConfigOpt) (
 
 	cm := manager.NewCertificateManager(ctx, r, svcRegistry, cfg)
 	um := testutils.NewUserManager()
-	tagManager := manager.NewTagManager(r)
+	resourceLabelManager := manager.NewResourceLabelManager(r)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 	kcm := manager.NewKeyConfigManager(r, cm, um, tagManager, cmkAuditor, eventFactory, cfg)
 
 	mappingService := mapping.NewFakeService()

--- a/internal/manager/workflow_test.go
+++ b/internal/manager/workflow_test.go
@@ -73,7 +73,8 @@ func SetupWorkflowManager(
 	tenantConfigManager := manager.NewTenantConfigManager(r, svcRegistry, nil)
 	cmkAuditor := auditor.New(t.Context(), cfg)
 	userManager := manager.NewUserManager(authzRepo, cmkAuditor)
-	tagManager := manager.NewTagManager(r)
+	resourceLabelManager := manager.NewResourceLabelManager(r)
+	tagManager := manager.NewTagManager(resourceLabelManager)
 	keyConfigManager := manager.NewKeyConfigManager(r, certManager, userManager, tagManager, cmkAuditor, nil, cfg)
 	groupManager := manager.NewGroupManager(r, svcRegistry, userManager)
 

--- a/internal/model/resource_label.go
+++ b/internal/model/resource_label.go
@@ -1,0 +1,55 @@
+package model
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/openkcm/cmk/internal/authz"
+)
+
+// ResourceType represents the type of resource that labels are attached to
+type ResourceType string
+
+const (
+	// ResourceTypeKey represents labels attached to cryptographic keys
+	ResourceTypeKey ResourceType = "KEY"
+	// ResourceTypeKeyConfig represents labels attached to key configurations (tags)
+	ResourceTypeKeyConfig ResourceType = "KEY_CONFIG"
+)
+
+// SystemTagKey is the special key used to identify tags (as opposed to regular labels)
+// Tags are stored as labels with this key to distinguish them from user-defined labels
+const SystemTagKey = "system.tag"
+
+// ResourceLabel is a unified model for both labels and tags across different resource types
+// Labels are key-value pairs attached to resources
+// Tags are a special case of labels using SystemTagKey as the key
+type ResourceLabel struct {
+	AutoTimeModel
+
+	ID           uuid.UUID    `gorm:"type:uuid;primaryKey"`
+	ResourceType ResourceType `gorm:"type:varchar(50);not null"`
+	ResourceID   uuid.UUID    `gorm:"type:uuid;not null"`
+	Key          string       `gorm:"type:varchar(255);not null"`
+	Value        string       `gorm:"type:varchar(255);not null"`
+}
+
+// TableResourceType returns the authz resource type
+func (m ResourceLabel) TableResourceType() authz.RepoResourceType {
+	return authz.RepoResourceTypeResourceLabel
+}
+
+func (m ResourceLabel) TableName() string {
+	return string(m.TableResourceType())
+}
+
+func (ResourceLabel) IsSharedModel() bool {
+	return false
+}
+
+func (m ResourceLabel) CheckAuthz(ctx context.Context,
+	authzHandler *authz.Handler[authz.RepoResourceType, authz.RepoAction],
+	action authz.RepoAction) (bool, error) {
+	return authz.CheckAuthz(ctx, authzHandler, m.TableResourceType(), action)
+}

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -114,7 +114,8 @@ func createManagers(
 
 	cm := manager.NewCertificateManager(ctx, authzRepo, svcRegistry, cfg)
 	um := manager.NewUserManager(authzRepo, cmkAuditor)
-	tagm := manager.NewTagManager(r)
+	resourceLabelManager := manager.NewResourceLabelManager(authzRepo)
+	tagm := manager.NewTagManager(resourceLabelManager)
 	kcm := manager.NewKeyConfigManager(authzRepo, cm, um, tagm, cmkAuditor, nil, cfg)
 
 	sys := manager.NewSystemManager(

--- a/internal/repo/query.go
+++ b/internal/repo/query.go
@@ -36,6 +36,8 @@ const (
 	KeyConfigIDField    QueryField = "key_configuration_id"
 	AdminGroupIDField   QueryField = "admin_group_id"
 	ResourceIDField     QueryField = "resource_id"
+	ResourceTypeField   QueryField = "resource_type"
+	ValueField          QueryField = "value"
 	IsPrimaryField      QueryField = "is_primary"
 	VersionField        QueryField = "version"
 	NativeIDField       QueryField = "native_id"

--- a/migrations/tenant/schema/00016_add_resource_labels_table.sql
+++ b/migrations/tenant/schema/00016_add_resource_labels_table.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS resource_labels (
+    id uuid NOT NULL,
+    resource_type varchar(50) NOT NULL,
+    resource_id uuid NOT NULL,
+    key varchar(255) NOT NULL,
+    value varchar(255) NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT resource_labels_pkey PRIMARY KEY (id)
+);
+
+-- Enable filtering by resource (resource_type + resource_id combination)
+CREATE INDEX idx_resource_labels_resource_type_id
+    ON resource_labels(resource_type, resource_id);
+
+-- Enable filtering by label/tag key
+CREATE INDEX idx_resource_labels_key
+    ON resource_labels(key);
+
+-- Enable combined filtering and enforce uniqueness per resource
+-- Prevents duplicate (resource_type, resource_id, key, value) combinations
+CREATE UNIQUE INDEX idx_resource_labels_unique
+    ON resource_labels(resource_type, resource_id, key, value);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_resource_labels_unique;
+DROP INDEX IF EXISTS idx_resource_labels_key;
+DROP INDEX IF EXISTS idx_resource_labels_resource_type_id;
+DROP TABLE IF EXISTS resource_labels;
+-- +goose StatementEnd

--- a/migrations/tenant/schema/00016_add_resource_labels_table.sql
+++ b/migrations/tenant/schema/00016_add_resource_labels_table.sql
@@ -19,16 +19,24 @@ CREATE INDEX idx_resource_labels_resource_type_id
 CREATE INDEX idx_resource_labels_key
     ON resource_labels(key);
 
--- Enable combined filtering and enforce uniqueness per resource
--- Prevents duplicate (resource_type, resource_id, key, value) combinations
-CREATE UNIQUE INDEX idx_resource_labels_unique
-    ON resource_labels(resource_type, resource_id, key, value);
+-- Enforce uniqueness: one value per (resource_type, resource_id, key) for labels
+-- Exception: system.tag key can have multiple values (multiple tags per resource)
+-- This prevents duplicate keys and matches label semantics (update by key, delete by key)
+CREATE UNIQUE INDEX idx_resource_labels_unique_key
+    ON resource_labels(resource_type, resource_id, key)
+    WHERE key != 'system.tag';
+
+-- For system tags, allow multiple values but prevent exact duplicates
+CREATE UNIQUE INDEX idx_resource_labels_unique_tag
+    ON resource_labels(resource_type, resource_id, key, value)
+    WHERE key = 'system.tag';
 
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-DROP INDEX IF EXISTS idx_resource_labels_unique;
+DROP INDEX IF EXISTS idx_resource_labels_unique_tag;
+DROP INDEX IF EXISTS idx_resource_labels_unique_key;
 DROP INDEX IF EXISTS idx_resource_labels_key;
 DROP INDEX IF EXISTS idx_resource_labels_resource_type_id;
 DROP TABLE IF EXISTS resource_labels;

--- a/migrations/tenant/schema/00017_migrate_labels_and_tags_data.sql
+++ b/migrations/tenant/schema/00017_migrate_labels_and_tags_data.sql
@@ -3,8 +3,10 @@
 
 -- Migrate existing key_labels to resource_labels
 -- Maps: key_labels -> resource_labels with resource_type='KEY'
+-- Note: With the new unique constraint on (resource_type, resource_id, key),
+-- if there are duplicate keys, only the most recently updated one is kept
 INSERT INTO resource_labels (id, resource_type, resource_id, key, value, created_at, updated_at)
-SELECT
+SELECT DISTINCT ON (resource_id, key)
     id,
     'KEY' AS resource_type,
     resource_id,
@@ -13,27 +15,29 @@ SELECT
     created_at,
     updated_at
 FROM key_labels
-ON CONFLICT (resource_type, resource_id, key, value) DO NOTHING;
+ORDER BY resource_id, key, updated_at DESC  -- Keep most recent if duplicates exist
+ON CONFLICT (resource_type, resource_id, key) DO NOTHING;
 
--- Migrate existing key_configuration_tags to resource_labels
--- Maps: key_configuration_tags + keyconfigurations_tags -> resource_labels
+-- Migrate existing key_configuration tags to resource_labels
+-- Maps: tags table (JSONB values) -> resource_labels
 -- with resource_type='KEY_CONFIG' and key='system.tag'
+-- The tags table was created in migration 00002, replacing the old keyconfigurations_tags structure
 DO $$
 BEGIN
-    -- These legacy tables may not exist on fresh installs (they are dropped in migration 00002).
-    IF to_regclass('public.keyconfigurations_tags') IS NOT NULL
-       AND to_regclass('public.key_configuration_tags') IS NOT NULL THEN
+    -- Check if tags table exists (it should, but check for safety)
+    IF to_regclass('tags') IS NOT NULL THEN
         INSERT INTO resource_labels (id, resource_type, resource_id, key, value, created_at, updated_at)
         SELECT
-            gen_random_uuid() AS id,  -- Generate new UUIDs for tag entries
+            gen_random_uuid() AS id,
             'KEY_CONFIG' AS resource_type,
-            kt.key_configuration_id AS resource_id,
+            t.id AS resource_id,  -- tags.id is the key_configuration_id
             'system.tag' AS key,
-            t.value AS value,
+            tag_value::text AS value,  -- Extract each tag from JSONB array
             CURRENT_TIMESTAMP AS created_at,
             CURRENT_TIMESTAMP AS updated_at
-        FROM keyconfigurations_tags kt
-        JOIN key_configuration_tags t ON kt.key_configuration_tag_id = t.id
+        FROM tags t,
+        LATERAL jsonb_array_elements_text(t.values) AS tag_value
+        WHERE t.values IS NOT NULL AND jsonb_array_length(t.values) > 0
         ON CONFLICT (resource_type, resource_id, key, value) DO NOTHING;
     END IF;
 END $$;

--- a/migrations/tenant/schema/00017_migrate_labels_and_tags_data.sql
+++ b/migrations/tenant/schema/00017_migrate_labels_and_tags_data.sql
@@ -16,7 +16,7 @@ SELECT DISTINCT ON (resource_id, key)
     updated_at
 FROM key_labels
 ORDER BY resource_id, key, updated_at DESC  -- Keep most recent if duplicates exist
-ON CONFLICT (resource_type, resource_id, key) DO NOTHING;
+ON CONFLICT (resource_type, resource_id, key) WHERE key != 'system.tag' DO NOTHING;
 
 -- Migrate existing key_configuration tags to resource_labels
 -- Maps: tags table (JSONB values) -> resource_labels
@@ -38,7 +38,7 @@ BEGIN
         FROM tags t,
         LATERAL jsonb_array_elements_text(t.values) AS tag_value
         WHERE t.values IS NOT NULL AND jsonb_array_length(t.values) > 0
-        ON CONFLICT (resource_type, resource_id, key, value) DO NOTHING;
+        ON CONFLICT (resource_type, resource_id, key, value) WHERE key = 'system.tag' DO NOTHING;
     END IF;
 END $$;
 

--- a/migrations/tenant/schema/00017_migrate_labels_and_tags_data.sql
+++ b/migrations/tenant/schema/00017_migrate_labels_and_tags_data.sql
@@ -1,0 +1,58 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Migrate existing key_labels to resource_labels
+-- Maps: key_labels -> resource_labels with resource_type='KEY'
+INSERT INTO resource_labels (id, resource_type, resource_id, key, value, created_at, updated_at)
+SELECT
+    id,
+    'KEY' AS resource_type,
+    resource_id,
+    key,
+    COALESCE(value, '') AS value,  -- Ensure value is not null
+    created_at,
+    updated_at
+FROM key_labels
+ON CONFLICT (resource_type, resource_id, key, value) DO NOTHING;
+
+-- Migrate existing key_configuration_tags to resource_labels
+-- Maps: key_configuration_tags + keyconfigurations_tags -> resource_labels
+-- with resource_type='KEY_CONFIG' and key='system.tag'
+DO $$
+BEGIN
+    -- These legacy tables may not exist on fresh installs (they are dropped in migration 00002).
+    IF to_regclass('public.keyconfigurations_tags') IS NOT NULL
+       AND to_regclass('public.key_configuration_tags') IS NOT NULL THEN
+        INSERT INTO resource_labels (id, resource_type, resource_id, key, value, created_at, updated_at)
+        SELECT
+            gen_random_uuid() AS id,  -- Generate new UUIDs for tag entries
+            'KEY_CONFIG' AS resource_type,
+            kt.key_configuration_id AS resource_id,
+            'system.tag' AS key,
+            t.value AS value,
+            CURRENT_TIMESTAMP AS created_at,
+            CURRENT_TIMESTAMP AS updated_at
+        FROM keyconfigurations_tags kt
+        JOIN key_configuration_tags t ON kt.key_configuration_tag_id = t.id
+        ON CONFLICT (resource_type, resource_id, key, value) DO NOTHING;
+    END IF;
+END $$;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Remove migrated key labels (based on resource_type='KEY')
+DELETE FROM resource_labels
+WHERE resource_type = 'KEY'
+AND id IN (SELECT id FROM key_labels);
+
+-- Remove migrated key configuration tags (based on resource_type='KEY_CONFIG' and key='system.tag')
+-- Note: Since we generated new UUIDs during migration, we can't match by ID
+-- Instead, we delete all KEY_CONFIG entries with system.tag key
+DELETE FROM resource_labels
+WHERE resource_type = 'KEY_CONFIG'
+AND key = 'system.tag';
+
+-- +goose StatementEnd

--- a/test/integration/tenant-manager/provisioning_test.go
+++ b/test/integration/tenant-manager/provisioning_test.go
@@ -62,7 +62,8 @@ func (s *DBSuite) SetupSuite() {
 
 	cm := manager.NewCertificateManager(ctx, r, svcRegistry, cfg)
 	um := manager.NewUserManager(r, cmkAuditor)
-	tagm := manager.NewTagManager(r)
+	resourceLabelManager := manager.NewResourceLabelManager(r)
+	tagm := manager.NewTagManager(resourceLabelManager)
 	kcm := manager.NewKeyConfigManager(r, cm, um, tagm, cmkAuditor, eventFactory, cfg)
 
 	sys := manager.NewSystemManager(


### PR DESCRIPTION
## Summary
- Introduce unified `resource_labels` model/table for labels and key-configuration tags.
- Migrate existing key labels and tags into `resource_labels` with new tenant migrations.
- Update managers, authz repo resource types/policies, and affected tests to use the new storage.

## Test plan
- `go test ./...` (integration tests may require local container/runtime setup)
