### PR TITLE
fix: resolve fragile tests

### DIFF
--- a/internal/api/transform/workflow/workflow_test.go
+++ b/internal/api/transform/workflow/workflow_test.go
@@ -265,11 +265,11 @@ func TestWorkflow_FromAPI_Expires(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 
-				nowTestTime := time.Now()
-				assert.Equal(t, tt.expiredNow, nowTestTime.After(*w.ExpiryDate))
+				now := time.Now()
+				assert.Equal(t, tt.expiredNow, now.After(*w.ExpiryDate))
 
-				maxTestTime := time.Now().AddDate(0, 0, defaultExpiry)
-				assert.Equal(t, tt.expiredAtMax, maxTestTime.After(*w.ExpiryDate))
+				maxTestTime := now.AddDate(0, 0, defaultExpiry)
+				assert.Equal(t, tt.expiredAtMax, !maxTestTime.Before(*w.ExpiryDate))
 			}
 		})
 	}

--- a/internal/testutils/container.go
+++ b/internal/testutils/container.go
@@ -69,10 +69,11 @@ func StartPostgresSQL(
 		postgres.WithUsername(user.Value),
 		postgres.WithPassword(secret.Value),
 		postgres.BasicWaitStrategies(),
-		testcontainers.WithStartupCommand(testcontainers.NewRawCommand([]string{
+		testcontainers.WithCmd(
 			"postgres",
+			"-c", "fsync=off",
 			"-c", "max_connections=1000",
-		})),
+		),
 		testcontainers.WithReuseByName(postgresContainer),
 	}, opts...)
 

--- a/internal/testutils/db.go
+++ b/internal/testutils/db.go
@@ -143,7 +143,7 @@ var (
 // By default, it uses TestDB configuration. Use opts to customize the setup.
 // This function is intended for use in unit tests.
 //
-//nolint:funlen,cyclop
+//nolint:funlen
 func NewTestDB(tb testing.TB, cfg TestDBConfig, opts ...TestDBConfigOpt) (*multitenancy.DB, []string, config.Database) {
 	tb.Helper()
 
@@ -168,18 +168,12 @@ func NewTestDB(tb testing.TB, cfg TestDBConfig, opts ...TestDBConfigOpt) (*multi
 		o(&cfg)
 	}
 
-	if !cfg.WithIsolatedService {
-		oncePostgres.Do(func() {
-			// All package processes share one postgres container. Each process gets its own isolated database,
-			// so tests never see each other's data.
-			StartPostgresSQL(tb, &cfg.dbCon)
-			cfg.dbCon = NewIsolatedDB(tb, cfg.dbCon)
-			dbCfg = cfg.dbCon
-		})
-		cfg.dbCon = dbCfg
-	} else {
+	oncePostgres.Do(func() {
 		StartPostgresSQL(tb, &cfg.dbCon)
-	}
+		cfg.dbCon = NewIsolatedDB(tb, cfg.dbCon)
+		dbCfg = cfg.dbCon
+	})
+	cfg.dbCon = dbCfg
 
 	dbCon := newTestDBCon(tb, &cfg)
 
@@ -364,11 +358,6 @@ type TestDBConfig struct {
 	// - Shared Tables
 	// - Multiple Tenants
 	CreateDatabase bool
-
-	// If true create an isolated PSQL instance
-	// In most cases this should not be set as it will take a longer time
-	// as the container needs to build and startup
-	WithIsolatedService bool
 
 	// Shared schema version to migrate up to
 	// If it's nil migrate to latest version

--- a/internal/testutils/db.go
+++ b/internal/testutils/db.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openkcm/common-sdk/pkg/commoncfg"
 	"github.com/pressly/goose/v3"
 	"github.com/stretchr/testify/assert"
-	"github.com/testcontainers/testcontainers-go"
+	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 
@@ -170,7 +170,10 @@ func NewTestDB(tb testing.TB, cfg TestDBConfig, opts ...TestDBConfigOpt) (*multi
 
 	if !cfg.WithIsolatedService {
 		oncePostgres.Do(func() {
-			StartPostgresSQL(tb, &cfg.dbCon, testcontainers.WithReuseByName(uuid.NewString()))
+			// All package processes share one postgres container. Each process gets its own isolated database,
+			// so tests never see each other's data.
+			StartPostgresSQL(tb, &cfg.dbCon)
+			cfg.dbCon = NewIsolatedDB(tb, cfg.dbCon)
 			dbCfg = cfg.dbCon
 		})
 		cfg.dbCon = dbCfg
@@ -179,11 +182,6 @@ func NewTestDB(tb testing.TB, cfg TestDBConfig, opts ...TestDBConfigOpt) (*multi
 	}
 
 	dbCon := newTestDBCon(tb, &cfg)
-
-	tb.Cleanup(func() {
-		sqlDB, _ := dbCon.DB.DB()
-		sqlDB.Close()
-	})
 
 	migrator, err := db.NewMigrator(sql.NewRepository(dbCon), &config.Config{Database: cfg.dbCon})
 	assert.NoError(tb, err)
@@ -286,13 +284,13 @@ func runMigration(
 	// Not set, migrate to latest
 	if version == nil {
 		_, err := migrator.MigrateToLatest(tb.Context(), req)
-		assert.NoError(tb, err)
+		require.NoError(tb, err)
 		return
 	}
 
 	if *version != 0 {
 		_, err := migrator.MigrateTo(tb.Context(), req, *version)
-		assert.NoError(tb, err)
+		require.NoError(tb, err)
 	} else {
 		return
 	}
@@ -313,10 +311,10 @@ func CreateDBTenant(
 		assert.NoError(tb, err)
 	})
 
-	assert.NoError(tb, dbCon.Create(&tenant).Error)
+	require.NoError(tb, dbCon.Create(&tenant).Error)
 
-	assert.NoError(tb, dbCon.RegisterModels(tb.Context(), &TestModel{}))
-	assert.NoError(tb, dbCon.MigrateTenantModels(tb.Context(), tenant.ID))
+	require.NoError(tb, dbCon.RegisterModels(tb.Context(), &TestModel{}))
+	require.NoError(tb, dbCon.MigrateTenantModels(tb.Context(), tenant.ID))
 }
 
 // WithInitTenants creates the provided tenants on the DB
@@ -425,9 +423,31 @@ func newTestDBCon(tb testing.TB, cfg *TestDBConfig) *multitenancy.DB {
 		[]config.Database{},
 		nil, // No tracing in tests
 	)
-	assert.NoError(tb, err)
+	require.NoError(tb, err)
+
+	tb.Cleanup(func() {
+		sqlDB, _ := con.DB.DB()
+		sqlDB.Close()
+	})
+
+	limitConnPool(tb, con)
 
 	return con
+}
+
+const maxTestConnsPerPool = 8
+
+// limitConnPool bounds the underlying database/sql pool of a test connection.
+func limitConnPool(tb testing.TB, con *multitenancy.DB) {
+	tb.Helper()
+
+	require.NotNil(tb, con, "cannot limit pool on a nil connection")
+
+	sqlDB, err := con.DB.DB()
+	require.NoError(tb, err)
+
+	sqlDB.SetMaxOpenConns(maxTestConnsPerPool)
+	sqlDB.SetMaxIdleConns(maxTestConnsPerPool)
 }
 
 // NewIsolatedDB creates a new database on a postgres instance and returns it
@@ -442,15 +462,18 @@ func NewIsolatedDB(tb testing.TB, cfg config.Database) config.Database {
 		[]config.Database{},
 		nil, // No tracing in tests
 	)
-	assert.NoError(tb, err)
+
+	require.NoError(tb, err)
 
 	tb.Cleanup(func() {
 		sqlDB, _ := con.DB.DB()
 		sqlDB.Close()
 	})
 
-	name := processNameForDB(tb.Name())
-	assert.NoError(tb, err)
+	limitConnPool(tb, con)
+
+	// Database names must be unique within a container. Add a random suffix.
+	name := uniqueDBName(tb.Name())
 
 	// No need to t.CleanUp as it only throws error on db error
 	err = con.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s;", name)).Error
@@ -461,6 +484,20 @@ func NewIsolatedDB(tb testing.TB, cfg config.Database) config.Database {
 	cfg.Name = name
 
 	return cfg
+}
+
+// uniqueDBName builds a unique database name from a test name by appending a random suffix.
+func uniqueDBName(testName string) string {
+	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")[:12]
+	base := processNameForDB(testName)
+
+	// Reserve room for the "_" separator and the suffix within the limit.
+	maxBase := MaxPSQLSchemaName - 1 - len(suffix) - 1
+	if len(base) > maxBase {
+		base = base[:maxBase]
+	}
+
+	return base + "_" + suffix
 }
 
 type migrator struct{}

--- a/test/db-migration/migration_test.go
+++ b/test/db-migration/migration_test.go
@@ -111,8 +111,7 @@ func assertVersion(t *testing.T, dbCon *multitenancy.DB, version int64, versionT
 
 func TestMissingSchemaScripts(t *testing.T) {
 	gooseMigrated, gooseTenant, _ := testutils.NewTestDB(t, testutils.TestDBConfig{
-		CreateDatabase:      true,
-		WithIsolatedService: true,
+		CreateDatabase: true,
 	})
 
 	// There is no current support to create a tenant if shared version is set to 0

--- a/test/integration/event-processor/reconciliation_test.go
+++ b/test/integration/event-processor/reconciliation_test.go
@@ -55,8 +55,7 @@ func setupTest(t *testing.T) tester {
 	db, tenants, dbConf := testutils.NewTestDB(
 		t,
 		testutils.TestDBConfig{
-			CreateDatabase:      true,
-			WithIsolatedService: true,
+			CreateDatabase: true,
 		},
 	)
 

--- a/test/integration/tenant-manager/tenant_manager_integration_test.go
+++ b/test/integration/tenant-manager/tenant_manager_integration_test.go
@@ -95,10 +95,10 @@ func setupInfrastructure(tb testing.TB) (
 	// Wait for gRPC servers to be ready
 	time.Sleep(1000 * time.Millisecond) // Give the servers time to start
 
-	multitenancyDB, _, dbConfig := testutils.NewTestDB(tb, testutils.TestDBConfig{
-		CreateDatabase:      true,
-		WithIsolatedService: true,
-	}, testutils.WithGenerateTenants(0), // Do not create tenants
+	multitenancyDB, _, dbConfig := testutils.NewTestDB(
+		tb, testutils.TestDBConfig{
+			CreateDatabase: true,
+		}, testutils.WithGenerateTenants(0), // Do not create tenants
 	)
 
 	return fakeTenantService, registryAddr, sessionManagerAddr, multitenancyDB, dbConfig

--- a/test/integration/tenant-manager/tenant_provisioning_test.go
+++ b/test/integration/tenant-manager/tenant_provisioning_test.go
@@ -140,8 +140,7 @@ func setupDB(t *testing.T) (*sql.ResourceRepository, *multitenancy.DB) {
 	t.Helper()
 
 	multitenancyDB, _, _ := testutils.NewTestDB(t, testutils.TestDBConfig{
-		CreateDatabase:      false, // false until testcontainers for TM is prepared to allow custom cmk db
-		WithIsolatedService: true,
+		CreateDatabase: false, // false until testcontainers for TM is prepared to allow custom cmk db
 	})
 
 	return sql.NewRepository(multitenancyDB), multitenancyDB


### PR DESCRIPTION
**What this PR does / why we need it:**
```
Makes the tests run stable and faster by fixing the shared test-Postgres setup and letting test packages run in parallel.
```

**Metric:**
Tests runtime is 80s-92s on my machine.

<img width="398" height="45" alt="Screenshot 2026-07-17 at 10 22 57" src="https://github.com/user-attachments/assets/92ef764c-70dd-4d95-895a-0c806613d84c" />