### PR TITLE
fix: add keystorePool supported regions configuration

### DIFF
--- a/charts/cmk/Chart.yaml
+++ b/charts/cmk/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.75
+version: 0.1.76
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cmk/templates/api-server/configmap.yaml
+++ b/charts/cmk/templates/api-server/configmap.yaml
@@ -75,5 +75,8 @@ data:
     landscape:
       {{- toYaml .landscape | nindent 6 }}
 
+    keystorePool:
+      {{- toYaml .keystorePool | nindent 6 }}
+
     {{- end }}
 {{- end }}

--- a/charts/cmk/values.yaml
+++ b/charts/cmk/values.yaml
@@ -874,11 +874,18 @@ config:
     # authContext: []
 
   # Keystore pool configuration
-  # keystorePool:
-  # Target number of keystores to keep in the pool
-  # size: 5
-  # Interval to report the size of the keystore pool
-  # interval: 10m
+  keystorePool:
+    # Target number of keystores to keep in the pool
+    size: 2
+    # Interval to report the size of the keystore pool
+    interval: 10m
+    # Supported regions configuration - should match the keystore plugin's supported regions
+    supportedRegions:
+      source: file
+      file:
+        path: /etc/credentials/keystore-plugins/management/supported-regions
+        format: json
+        jsonPath: "$.regions"
 
   landscape:
     # name: one of Local, Staging, Canary, Production

--- a/config.yaml
+++ b/config.yaml
@@ -220,6 +220,19 @@ workflows:
   enabled: false
   minimumApprovals: 2
 
+keystorePool:
+  size: 2
+  interval: 10m
+  supportedRegions:
+    source: embedded
+    value: |
+      [
+        {"name": "Europe (Frankfurt)", "technicalName": "eu-central-1"},
+        {"name": "Europe (Ireland)", "technicalName": "eu-west-1"},
+        {"name": "Europe (London)", "technicalName": "eu-west-2"},
+        {"name": "United States (N. Virginia)", "technicalName": "us-east-1"},
+        {"name": "United States (Ohio)", "technicalName": "us-east-2"}
+      ]
 certificates:
   rootCertURL: https://aia.pki.co.example.com/aia/EXAMPLE%20Cloud%20Root%20CA.crt
   validityDays: 30


### PR DESCRIPTION
  **What this PR does / why we need it**:
  This PR fixes a chicken-and-egg problem where the UI cannot display supported regions for BYOK key creation before the first key is created.

  Previously, the /keystores endpoint returned empty supportedRegions because the keystore configuration is only retrieved from the pool when the first BYOK key is created. However, the UI needs this list to
  populate the region dropdown before any key exists.

  The solution adds a keystorePool.supportedRegions configuration that allows CMK to return the supported regions list without requiring a keystore to be retrieved from the pool. This configuration:
  - For deployed environments: references the same file used by the keystore management plugin (/etc/credentials/keystore-plugins/management/supported-regions)
  - For local development: uses an embedded configuration with the supported regions list

  This ensures the UI can display available regions immediately when BYOK is enabled, without wasting pool resources for tenants that never use BYOK.

  **Special notes for your reviewer**:
  - The code to support this configuration already exists in internal/manager/tenantconfigs.go (lines 200-215)
  - This PR only adds the missing configuration section
  - The values.yaml uses a file-based source (production), while config.yaml uses embedded source (local dev)
  - Verify that the JSON structure matches what the code expects: {"regions": [{"name": "...", "technicalName": "..."}]}

  **Release note**:
  fix: BYOK supported regions are now available in the UI before creating the first key