### PR TITLE
fix: add proper error handling for INVALID_KEY_ATTRIBUTE

### DIFF
--- a/internal/api/transform/key/transformer/transformer.go
+++ b/internal/api/transform/key/transformer/transformer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	keystoreErrs "github.com/openkcm/plugin-sdk/pkg/plugin/keystore/errors"
 
@@ -16,7 +15,8 @@ import (
 )
 
 const (
-	GRPCErrorCodeInvalidAccessData errs.GRPCErrorCode = "INVALID_ACCESS_DATA"
+	GRPCErrorCodeInvalidAccessData   errs.GRPCErrorCode = "INVALID_ACCESS_DATA"
+	GRPCErrorCodeInvalidKeyAttribute errs.GRPCErrorCode = "INVALID_KEY_ATTRIBUTE"
 )
 
 var (
@@ -26,6 +26,10 @@ var (
 	ErrGRPCInvalidAccessData  = errs.GRPCError{
 		Code:        GRPCErrorCodeInvalidAccessData,
 		BaseMessage: "failed to validate access data for the keystore provider",
+	}
+	ErrGRPCValidateKey = errs.GRPCError{
+		Code:        GRPCErrorCodeInvalidKeyAttribute,
+		BaseMessage: "invalid key attribute for the keystore provider",
 	}
 )
 
@@ -88,7 +92,7 @@ func (v PluginProviderTransformer) ValidateAPI(ctx context.Context, k cmkapi.Key
 	}
 
 	if !response.IsValid {
-		return errs.Wrapf(ErrValidateKey, response.Message)
+		return errors.Join(ErrValidateKey, ErrGRPCValidateKey.WithReason(response.Message))
 	}
 
 	return nil
@@ -167,11 +171,11 @@ func (v PluginProviderTransformer) GetRegion(
 		ManagementAccessData: management,
 	})
 	if err != nil {
-		return "", errs.Wrapf(ErrExtractKeyRegion, fmt.Sprintf("failed to extract key region: %v", err))
+		return "", errors.Join(ErrExtractKeyRegion, ErrGRPCValidateKey.WithReason(err.Error()))
 	}
 
 	if response.Region == "" {
-		return "", errs.Wrapf(ErrExtractKeyRegion, "extracted region is empty")
+		return "", errors.Join(ErrExtractKeyRegion, ErrGRPCValidateKey.WithReason("extracted region is empty"))
 	}
 
 	return response.Region, nil

--- a/internal/api/transform/key/transformer/transformer_test.go
+++ b/internal/api/transform/key/transformer/transformer_test.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/openkcm/cmk/internal/api/cmkapi"
 	"github.com/openkcm/cmk/internal/api/transform/key/transformer"
+	"github.com/openkcm/cmk/internal/errs"
 	"github.com/openkcm/cmk/internal/testutils"
+	"github.com/openkcm/cmk/internal/testutils/testplugins"
 )
 
 func getPluginProviderTransformer(t *testing.T) *transformer.PluginProviderTransformer {
@@ -34,6 +36,29 @@ func TestValidatesAPIKey(t *testing.T) {
 	err := tf.ValidateAPI(t.Context(), key)
 
 	assert.NoError(t, err)
+}
+
+func TestValidatesAPIKey_InvalidRegion(t *testing.T) {
+	km := testplugins.NewTestKeyManagement(true, true).WithValidRegions("us-east-1")
+
+	svcRegistry := testutils.NewTestPlugins(testplugins.WithKeyManagement("TEST", km))
+	tf, err := transformer.NewPluginProviderTransformer(svcRegistry, "TEST")
+	assert.NoError(t, err)
+
+	key := cmkapi.Key{
+		Type:      cmkapi.KeyTypeBYOK,
+		Algorithm: new(cmkapi.KeyAlgorithmAES256),
+		Region:    new("eu-west-1"),
+	}
+
+	gotErr := tf.ValidateAPI(t.Context(), key)
+
+	assert.ErrorIs(t, gotErr, transformer.ErrValidateKey)
+	assert.ErrorIs(t, gotErr, transformer.ErrGRPCValidateKey)
+
+	var grpcErr errs.GRPCError
+	assert.ErrorAs(t, gotErr, &grpcErr)
+	assert.Equal(t, "region eu-west-1 is not supported", grpcErr.Reason)
 }
 
 func TestSerializesKeyAccessData(t *testing.T) {
@@ -103,4 +128,25 @@ func TestExtractRegion(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "test-region", region)
+}
+
+func TestExtractRegion_InvalidNativeID(t *testing.T) {
+	km := testplugins.NewTestKeyManagement(true, true).WithValidNativeIDPattern(`^valid-key/`)
+
+	svcRegistry := testutils.NewTestPlugins(testplugins.WithKeyManagement("TEST", km))
+	tf, err := transformer.NewPluginProviderTransformer(svcRegistry, "TEST")
+	assert.NoError(t, err)
+
+	key := cmkapi.Key{
+		NativeID: new("invalid-native-id"),
+	}
+
+	_, gotErr := tf.GetRegion(t.Context(), key)
+
+	assert.ErrorIs(t, gotErr, transformer.ErrExtractKeyRegion)
+	assert.ErrorIs(t, gotErr, transformer.ErrGRPCValidateKey)
+
+	var grpcErr errs.GRPCError
+	assert.ErrorAs(t, gotErr, &grpcErr)
+	assert.Contains(t, grpcErr.Reason, "invalid-native-id")
 }

--- a/internal/apierrors/key.go
+++ b/internal/apierrors/key.go
@@ -251,6 +251,15 @@ var key = []errs.ExposedErrors[*APIError]{
 		},
 	},
 	{
+		InternalErrorChain: []error{ErrTransformKeyFromAPI, transformer.ErrGRPCValidateKey},
+		ExposedError: &APIError{
+			Code:    "INVALID_KEY_ATTRIBUTE",
+			Message: "Invalid key attribute provided",
+			Status:  http.StatusBadRequest,
+		},
+		ContextGetter: errs.GetGRPCErrorContext,
+	},
+	{
 		InternalErrorChain: []error{ErrTransformKeyFromAPI, transformer.ErrGRPCInvalidAccessData},
 		ExposedError: &APIError{
 			Code:    "INVALID_ACCESS_DATA",

--- a/internal/controllers/cmk/key_controller_test.go
+++ b/internal/controllers/cmk/key_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openkcm/cmk/internal/repo"
 	"github.com/openkcm/cmk/internal/repo/sql"
 	"github.com/openkcm/cmk/internal/testutils"
+	"github.com/openkcm/cmk/internal/testutils/testplugins"
 	cmkcontext "github.com/openkcm/cmk/utils/context"
 )
 
@@ -598,6 +599,70 @@ func TestKeyControllerPostKeysDrainedKeystorePool(t *testing.T) {
 		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 		response := testutils.GetJSONBody[cmkapi.ErrorMessage](t, w)
 		assert.Equal(t, "KEYSTORE_POOL_DRAINED", response.Error.Code)
+	})
+}
+
+func TestKeyControllerPostKeysInvalidKeyAttribute(t *testing.T) {
+	db, tenants, dbCfg := testutils.NewTestDB(t, testutils.TestDBConfig{
+		CreateDatabase: true,
+	})
+	keyStorage := testutils.NewTestSigningKeyStorage(t)
+	tenant := tenants[0]
+
+	km := testplugins.NewTestKeyManagement(true, true).WithValidRegions("us-east-1")
+	sv := testutils.NewAPIServer(t, db, testutils.TestAPIServerConfig{
+		Registry: testutils.NewTestPlugins(testplugins.WithKeyManagement(providerTest, km)),
+		Config: config.Config{
+			Database: dbCfg,
+			CryptoLayer: config.CryptoLayer{
+				CertX509Trusts: commoncfg.SourceRef{
+					Source: commoncfg.EmbeddedSourceValue,
+					Value:  "[]",
+				},
+			},
+		},
+		EnableBusinessUserDataMW: true,
+		SigningKeyStorage:        keyStorage,
+	})
+
+	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
+	r := sql.NewRepository(db)
+
+	authClient := testutils.NewAuthClient(ctx, t, r, testutils.WithKeyAdminRole())
+	keyConfig := testutils.NewKeyConfig(func(_ *model.KeyConfiguration) {},
+		testutils.WithAuthBusinessUserDataKC(authClient))
+	tenantDefaultCert := testutils.NewCertificate(func(_ *model.Certificate) {})
+	testutils.CreateTestEntities(ctx, t, r, tenantDefaultCert, keyConfig,
+		keystore, keystoreDefaultCert, keystoreKeyMgmtCert)
+
+	privateKey, ok := keyStorage.GetPrivateKey(0)
+	assert.True(t, ok, "test key should exist")
+	headers := testutils.NewSignedBusinessUserDataHeaders(t, &auth.ClientData{
+		Identifier: authClient.Identifier,
+		Groups:     []string{authClient.Group.IAMIdentifier},
+	}, privateKey, 0)
+
+	t.Run("POST BYOK key with unsupported region", func(t *testing.T) {
+		w := testutils.MakeHTTPRequest(t, sv, testutils.RequestOptions{
+			Method:   http.MethodPost,
+			Endpoint: "keys",
+			Tenant:   tenant,
+			Body: testutils.WithJSON(t, map[string]any{
+				"name":               "byok-bad-region",
+				"type":               string(cmkapi.KeyTypeBYOK),
+				"keyConfigurationID": keyConfig.ID,
+				"provider":           providerTest,
+				"algorithm":          string(cmkapi.KeyAlgorithmAES256),
+				"region":             "eu-west-1",
+			}),
+			Headers: headers,
+		})
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		response := testutils.GetJSONBody[cmkapi.ErrorMessage](t, w)
+		assert.Equal(t, "INVALID_KEY_ATTRIBUTE", response.Error.Code)
+		assert.NotNil(t, response.Error.Context)
+		assert.Contains(t, *response.Error.Context, "reason")
 	})
 }
 

--- a/internal/errs/grpc.go
+++ b/internal/errs/grpc.go
@@ -49,6 +49,11 @@ func (e GRPCError) FromStatusError(err error) GRPCError {
 	return e
 }
 
+func (e GRPCError) WithReason(reason string) GRPCError {
+	e.Reason = reason
+	return e
+}
+
 type JoinedError interface {
 	Unwrap() []error
 }

--- a/internal/testutils/testplugins/key_management.go
+++ b/internal/testutils/testplugins/key_management.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/google/uuid"
@@ -25,8 +26,9 @@ var (
 	PendingImportKeyStatus   = "PENDING_IMPORT"
 	PendingDeletionKeyStatus = "PENDING_DELETION"
 
-	ErrKeyIDIsNil          = errors.New("keyId is nil")
-	ErrTransformAccessData = errors.New("failed to transform access data")
+	ErrKeyIDIsNil                = errors.New("keyId is nil")
+	ErrTransformAccessData       = errors.New("failed to transform access data")
+	ErrNativeKeyIDInvalidPattern = errors.New("native key ID does not match valid pattern")
 
 	// ValidManagementAccessData is the management access data the test plugin accepts
 	// in ValidateKeyAccessData. It mirrors the fields returned by CreateKeystore and
@@ -53,9 +55,11 @@ var InitialKeys = map[string]KeyRecord{
 }
 
 type TestKeyManagement struct {
-	KeyStore  map[string]*KeyRecord
-	IsHYOK    bool
-	IsDefault bool
+	KeyStore             map[string]*KeyRecord
+	IsHYOK               bool
+	IsDefault            bool
+	validRegions         map[string]bool // if non-nil, ValidateKey rejects regions not in this set
+	validNativeIDPattern *regexp.Regexp  // if non-nil, ExtractKeyRegion rejects non-matching native IDs
 }
 
 var _ keymanagement.KeyManagement = (*TestKeyManagement)(nil)
@@ -70,6 +74,22 @@ func NewTestKeyManagement(isHYOK, isDefault bool) *TestKeyManagement {
 		km.HandleKeyRecord(keyID, record.Status)
 	}
 	return km
+}
+
+// WithValidRegions restricts ValidateKey to the given regions
+func (s *TestKeyManagement) WithValidRegions(regions ...string) *TestKeyManagement {
+	s.validRegions = make(map[string]bool, len(regions))
+	for _, r := range regions {
+		s.validRegions[r] = true
+	}
+	return s
+}
+
+// WithValidNativeIDPattern restricts ExtractKeyRegion to native IDs matching the given pattern,
+// returning an error for non-matching IDs.
+func (s *TestKeyManagement) WithValidNativeIDPattern(pattern string) *TestKeyManagement {
+	s.validNativeIDPattern = regexp.MustCompile(pattern)
+	return s
 }
 
 func (s *TestKeyManagement) ServiceInfo() api.Info {
@@ -225,8 +245,14 @@ func (s *TestKeyManagement) ImportKeyMaterial(
 
 func (s *TestKeyManagement) ValidateKey(
 	_ context.Context,
-	_ *keymanagement.ValidateKeyRequest,
+	req *keymanagement.ValidateKeyRequest,
 ) (*keymanagement.ValidateKeyResponse, error) {
+	if s.validRegions != nil && !s.validRegions[req.Region] {
+		return &keymanagement.ValidateKeyResponse{
+			IsValid: false,
+			Message: fmt.Sprintf("region %s is not supported", req.Region),
+		}, nil
+	}
 	return &keymanagement.ValidateKeyResponse{IsValid: true}, nil
 }
 
@@ -291,7 +317,10 @@ func (s *TestKeyManagement) TransformCryptoAccessData(
 
 func (s *TestKeyManagement) ExtractKeyRegion(
 	_ context.Context,
-	_ *keymanagement.ExtractKeyRegionRequest,
+	req *keymanagement.ExtractKeyRegionRequest,
 ) (*keymanagement.ExtractKeyRegionResponse, error) {
+	if s.validNativeIDPattern != nil && !s.validNativeIDPattern.MatchString(req.NativeKeyID) {
+		return nil, fmt.Errorf("%w: %q", ErrNativeKeyIDInvalidPattern, req.NativeKeyID)
+	}
 	return &keymanagement.ExtractKeyRegionResponse{Region: "test-region"}, nil
 }


### PR DESCRIPTION
Error will be returned similar to INVALID_ACCESS_DATA + HTTP/400, instead of just TRANSFORM_API_KEY_ERROR + HTTP/500