### PR TITLE
feat(KMS20-7129): add DPP security tests

### DIFF
--- a/test/security/dpp/audit_attribution_test.go
+++ b/test/security/dpp/audit_attribution_test.go
@@ -1,0 +1,74 @@
+package dpp_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkcm/cmk/internal/constants"
+	cmkcontext "github.com/openkcm/cmk/utils/context"
+)
+
+// TestAuditLogAttributionNoUUIDMax verifies that internal processes (task-worker,
+// event-reconciler, operator etc.) are attributed to their role identifier in
+// audit events rather than falling back to uuid.Max
+// (00000000-0000-0000-0000-000000000000).
+// uuid.Max fallback occurs when neither business user data nor internal role
+// is present in the context — internal processes must inject their role.
+func TestAuditLogAttributionNoUUIDMax(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupContext func(ctx context.Context) context.Context
+		wantUUIDMax  bool
+	}{
+		{
+			name: "internal process with role set — must not use uuid.Max",
+			setupContext: func(ctx context.Context) context.Context {
+				ctx, err := cmkcontext.InjectInternalUserData(ctx, constants.InternalTaskProcessingRole)
+				require.NoError(t, err)
+				return ctx
+			},
+			wantUUIDMax: false,
+		},
+		{
+			name: "internal process with event reconciler role — must not use uuid.Max",
+			setupContext: func(ctx context.Context) context.Context {
+				ctx, err := cmkcontext.InjectInternalUserData(ctx, constants.InternalEventReconcilerRole)
+				require.NoError(t, err)
+				return ctx
+			},
+			wantUUIDMax: false,
+		},
+		{
+			name: "context with no identity — falls back to uuid.Max in auditor",
+			setupContext: func(ctx context.Context) context.Context {
+				return ctx // no identity injected
+			},
+			wantUUIDMax: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := cmkcontext.CreateTenantContext(t.Context(), "test-tenant")
+			ctx = tt.setupContext(ctx)
+
+			userID, err := cmkcontext.ExtractUserIdentifier(ctx)
+
+			if tt.wantUUIDMax {
+				// When no identity is set, ExtractUserIdentifier returns an error
+				// and auditor.go falls back to uuid.Max — document this behaviour.
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.NotEqual(t, uuid.Max.String(), userID,
+					"internal process audit events must not be attributed to uuid.Max")
+				assert.NotEmpty(t, userID,
+					"internal process must have a non-empty identity in audit events")
+			}
+		})
+	}
+}

--- a/test/security/dpp/pii_in_error_responses_test.go
+++ b/test/security/dpp/pii_in_error_responses_test.go
@@ -1,0 +1,93 @@
+package dpp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkcm/cmk/internal/repo/sql"
+	"github.com/openkcm/cmk/internal/testutils"
+	cmkcontext "github.com/openkcm/cmk/utils/context"
+)
+
+// reEmail matches any email address in a response body.
+var reEmail = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
+
+// TestNoPIIInErrorResponses verifies that API error responses do not echo
+// personal data fields (user identity, group names, auth context values) back
+// to the caller. Error responses must contain only structured error codes and
+// generic messages, not internal identity details.
+//
+// Note: successful (2xx) responses are permitted to contain identity data —
+// for example, group listings and workflow approver selection legitimately
+// expose user identifiers to authenticated users within the same tenant.
+// This test targets error paths only, where identity leakage is never
+// intentional.
+func TestNoPIIInErrorResponses(t *testing.T) {
+	db, tenants, _ := testutils.NewTestDB(t, testutils.TestDBConfig{})
+	tenant := tenants[0]
+	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
+
+	r := sql.NewRepository(db)
+	authClient := testutils.NewAuthClient(ctx, t, r, testutils.WithKeyAdminRole())
+
+	sv := testutils.NewAPIServer(t, db, testutils.TestAPIServerConfig{})
+
+	// piiValues are real-looking personal data values that must not be
+	// reflected back in any error response body.
+	piiValues := []string{
+		authClient.Identifier,
+		authClient.Group.IAMIdentifier,
+		tenant,
+	}
+
+	t.Run("404 for unknown resource does not echo identity", func(t *testing.T) {
+		w := testutils.MakeHTTPRequest(t, sv, testutils.RequestOptions{
+			Method:            http.MethodGet,
+			Endpoint:          "/systems/00000000-0000-0000-0000-000000000000",
+			Tenant:            tenant,
+			AdditionalContext: authClient.GetClientMap(),
+		})
+		require.Equal(t, http.StatusNotFound, w.Code)
+
+		body := w.Body.String()
+		assertNoPIIInBody(t, body, piiValues)
+	})
+
+	t.Run("400 for malformed request does not echo identity", func(t *testing.T) {
+		w := testutils.MakeHTTPRequest(t, sv, testutils.RequestOptions{
+			Method:            http.MethodGet,
+			Endpoint:          "/systems?$filter=invalid filter syntax !!!",
+			Tenant:            tenant,
+			AdditionalContext: authClient.GetClientMap(),
+		})
+		require.Equal(t, http.StatusBadRequest, w.Code)
+
+		body := w.Body.String()
+		assertNoPIIInBody(t, body, piiValues)
+	})
+}
+
+func assertNoPIIInBody(t *testing.T, body string, piiValues []string) {
+	t.Helper()
+
+	// Ensure the response is valid JSON — error responses must be structured.
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(body), &parsed),
+		"error response must be valid JSON, got: %s", body)
+
+	for _, pii := range piiValues {
+		if pii == "" {
+			continue
+		}
+		assert.NotContains(t, body, pii,
+			"error response must not contain personal data value %q", pii)
+	}
+
+	assert.Empty(t, reEmail.FindString(body),
+		"error response must not contain an email address, got: %s", body)
+}

--- a/test/security/dpp/pii_in_logs_test.go
+++ b/test/security/dpp/pii_in_logs_test.go
@@ -1,0 +1,72 @@
+package dpp_test
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	slogctx "github.com/veqryn/slog-context"
+
+	"github.com/openkcm/cmk/internal/repo/sql"
+	"github.com/openkcm/cmk/internal/testutils"
+	cmkcontext "github.com/openkcm/cmk/utils/context"
+)
+
+// piiFields are the personal data field keys that must not appear in logs at
+// the production log level (info/warn). These are fields confirmed present in
+// debug-level statements during DPP code review.
+var piiFields = []string{
+	"group",
+	"iamIdentifiers",
+	"UserName",
+	"userName",
+}
+
+// newInfoLevelLogBuffer returns a logger at info level and the buffer it writes to.
+// This simulates the production log level.
+func newInfoLevelLogBuffer() (*slog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	handler := slogctx.NewHandler(slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}), nil)
+	return slog.New(handler), buf
+}
+
+// TestNoPIIInLogsAtProductionLogLevel verifies that personal data fields
+// (group memberships, IAM identifiers, user names) are not written to logs
+// when the logger is set to info level (the production log level).
+// These fields appear only in debug-level statements and must not be visible
+// in production logs.
+func TestNoPIIInLogsAtProductionLogLevel(t *testing.T) {
+	db, tenants, _ := testutils.NewTestDB(t, testutils.TestDBConfig{})
+	tenant := tenants[0]
+	ctx := cmkcontext.CreateTenantContext(t.Context(), tenant)
+
+	r := sql.NewRepository(db)
+	authClient := testutils.NewAuthClient(ctx, t, r, testutils.WithKeyAdminRole())
+
+	logger, buf := newInfoLevelLogBuffer()
+	slog.SetDefault(logger)
+
+	sv := testutils.NewAPIServer(t, db, testutils.TestAPIServerConfig{})
+
+	// Make an authenticated API call that exercises the business user data
+	// middleware — the code path that logs group and auth context fields.
+	w := testutils.MakeHTTPRequest(t, sv, testutils.RequestOptions{
+		Method:            http.MethodGet,
+		Endpoint:          "/keyConfigurations",
+		Tenant:            tenant,
+		AdditionalContext: authClient.GetClientMap(),
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	logOutput := buf.String()
+	for _, field := range piiFields {
+		assert.NotContains(t, logOutput, `"`+field+`":`,
+			"PII field %q must not appear in logs at production log level (info)", field)
+	}
+}

--- a/test/security/dpp/workflow_approver_isolation_test.go
+++ b/test/security/dpp/workflow_approver_isolation_test.go
@@ -1,0 +1,158 @@
+package dpp_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openkcm/common-sdk/pkg/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkcm/cmk/internal/auditor"
+	authz_loader "github.com/openkcm/cmk/internal/authz/loader"
+	authz_repo "github.com/openkcm/cmk/internal/authz/repo"
+	"github.com/openkcm/cmk/internal/clients"
+	"github.com/openkcm/cmk/internal/config"
+	"github.com/openkcm/cmk/internal/constants"
+	"github.com/openkcm/cmk/internal/manager"
+	"github.com/openkcm/cmk/internal/model"
+	"github.com/openkcm/cmk/internal/pluginregistry/service/api/identitymanagement"
+	"github.com/openkcm/cmk/internal/repo"
+	"github.com/openkcm/cmk/internal/repo/sql"
+	"github.com/openkcm/cmk/internal/testutils"
+	"github.com/openkcm/cmk/internal/testutils/testplugins"
+	cmkcontext "github.com/openkcm/cmk/utils/context"
+)
+
+// TestWorkflowApproverIsolation verifies that when a workflow is created,
+// only users who are members of the key configuration's admin group are
+// offered as approvers. Users in other groups must not appear, regardless
+// of how many groups exist in the tenant.
+//
+// This is a DPP isolation control: the approver list must be scoped to the
+// relevant group, not the full user population of the tenant.
+func TestWorkflowApproverIsolation(t *testing.T) {
+	const (
+		adminGroupName   = "key-admins"
+		adminGroupSCIM   = "scim-key-admins-id"
+		otherGroupName   = "other-group"
+		otherGroupSCIM   = "scim-other-group-id"
+		auditorGroup     = "auditors"
+		auditorGroupSCIM = "scim-auditors-id"
+
+		adminUser1 = "admin-user-1"
+		adminUser2 = "admin-user-2"
+		otherUser  = "other-user-1"
+	)
+
+	idmPlugin := testplugins.NewTestIdentityManagement(
+		testplugins.WithGroups(map[string]string{
+			adminGroupName: adminGroupSCIM,
+			otherGroupName: otherGroupSCIM,
+			auditorGroup:   auditorGroupSCIM,
+		}),
+		testplugins.WithGroupMembership(map[string][]string{
+			adminGroupSCIM:   {adminUser1, adminUser2},
+			otherGroupSCIM:   {otherUser},
+			auditorGroupSCIM: {},
+		}),
+		testplugins.WithUsers([]identitymanagement.User{
+			{ID: adminUser1, Name: "admin1@example.com", Email: "admin1@example.com"},
+			{ID: adminUser2, Name: "admin2@example.com", Email: "admin2@example.com"},
+			{ID: otherUser, Name: "other@example.com", Email: "other@example.com"},
+		}),
+	)
+
+	db, tenants, _ := testutils.NewTestDB(t, testutils.TestDBConfig{})
+	tenant := tenants[0]
+	r := sql.NewRepository(db)
+
+	authzRepoLoader := authz_loader.NewRepoAuthzLoader(t.Context(), r, &config.Config{})
+	authzRepoInst := authz_repo.NewAuthzRepo(r, authzRepoLoader)
+	svcRegistry := testutils.NewTestPlugins(testplugins.WithIdentityManagement(idmPlugin))
+	cfg := &config.Config{}
+
+	cmkAuditor := auditor.New(t.Context(), cfg)
+	certManager := manager.NewCertificateManager(t.Context(), r, svcRegistry, cfg)
+	tenantConfigManager := manager.NewTenantConfigManager(r, svcRegistry, cfg, certManager)
+	userManager := manager.NewUserManager(authzRepoInst, cmkAuditor)
+	tagManager := manager.NewTagManager(r)
+	keyConfigManager := manager.NewKeyConfigManager(r, certManager, userManager, tagManager, cmkAuditor, nil, cfg)
+	groupManager := manager.NewGroupManager(r, svcRegistry, userManager)
+	clientsFactory, err := clients.NewFactory(cfg.Services)
+	require.NoError(t, err)
+	systemManager := manager.NewSystemManager(t.Context(), r, nil, clientsFactory, nil, svcRegistry, cfg, keyConfigManager, userManager)
+	keym := manager.NewKeyManager(r, svcRegistry, tenantConfigManager, keyConfigManager, userManager, certManager, nil, cmkAuditor)
+	m := manager.NewWorkflowManager(r, svcRegistry, keym, keyConfigManager, systemManager, groupManager, userManager, nil, tenantConfigManager, cfg)
+
+	ctx := testutils.CreateCtxWithTenant(tenant)
+	ctxSys, err := cmkcontext.BusinessToInternalContext(ctx, constants.InternalTaskWorkflowApproversRole)
+	require.NoError(t, err)
+
+	// Enable workflow feature
+	workflowConfig := testutils.NewWorkflowConfig(func(_ *model.TenantConfig) {})
+	testutils.CreateTestEntities(ctx, t, r, workflowConfig)
+
+	// Seed all groups in DB
+	adminGroupModel := testutils.NewGroup(func(g *model.Group) {
+		g.Name = adminGroupName
+		g.IAMIdentifier = adminGroupName
+		g.Role = constants.KeyAdminRole
+	})
+	otherGroupModel := testutils.NewGroup(func(g *model.Group) {
+		g.Name = otherGroupName
+		g.IAMIdentifier = otherGroupName
+		g.Role = constants.KeyAdminRole
+	})
+	auditorGroupModel := testutils.NewGroup(func(g *model.Group) {
+		g.Name = auditorGroup
+		g.IAMIdentifier = auditorGroup
+		g.Role = constants.TenantAuditorRole
+	})
+	testutils.CreateTestEntities(ctxSys, t, r, adminGroupModel, otherGroupModel, auditorGroupModel)
+
+	// Key config is administered by adminGroup only
+	key := testutils.NewKey(func(_ *model.Key) {})
+	keyConfig := testutils.NewKeyConfig(func(c *model.KeyConfiguration) {
+		c.PrimaryKeyID = &key.ID
+		c.AdminGroup = *adminGroupModel
+		c.AdminGroupID = adminGroupModel.ID
+	})
+	testutils.CreateTestEntities(ctxSys, t, r, key, keyConfig)
+
+	// Create a workflow for that key
+	wf := testutils.NewWorkflow(func(w *model.Workflow) {
+		w.State = model.WorkflowStateInitial
+		w.ActionType = model.WorkflowActionTypeDelete
+		w.ArtifactType = model.WorkflowArtifactTypeKey
+		w.ArtifactID = key.ID
+		w.Approvers = nil
+	})
+	err = r.Create(ctxSys, wf)
+	require.NoError(t, err)
+
+	// AutoAssignApprovers is normally async; call it directly here.
+	// The context must carry business user data for the auditor group check.
+	ctxWithUser := context.WithValue(ctx, constants.BusinessUserData, &auth.ClientData{
+		Identifier: "testuser",
+		Groups:     []string{auditorGroup},
+	})
+	_, err = m.AutoAssignApprovers(ctxWithUser, wf.ID)
+	require.NoError(t, err)
+
+	approvers, _, err := m.ListWorkflowApprovers(ctxSys, wf.ID, false, repo.Pagination{})
+	require.NoError(t, err)
+
+	approverIDs := make([]string, 0, len(approvers))
+	for _, a := range approvers {
+		approverIDs = append(approverIDs, a.UserID)
+	}
+
+	// Only admin group members should be approvers
+	assert.ElementsMatch(t, []string{adminUser1, adminUser2}, approverIDs,
+		"approvers must be scoped to the key config's admin group")
+
+	// Users from other groups must not appear
+	assert.NotContains(t, approverIDs, otherUser,
+		"user from unrelated group must not appear as an approver")
+}


### PR DESCRIPTION
## Summary

Implements four automated DPP security tests in `test/security/dpp/` as evidence for SDOL-008 and DPP-254 compliance:

- **TestNoPIIInLogsAtProductionLogLevel** — asserts PII fields (email, IAM identifiers, group memberships) are not written to logs at the production log level
- **TestAuditLogAttributionNoUUIDMax** — asserts internal processes are attributed to their role identity, not the uuid.Max sentinel
- **TestNoPIIInErrorResponses** — asserts API error responses do not echo PII (email, IAM identifier, tenant ID)
- **TestWorkflowApproverIsolation** — asserts approver selection for a workflow is scoped to the correct group only

## Jira

https://jira.tools.sap/browse/KMS20-7129