### PR TITLE
fix: remove YAML config fallback on supported regions

### DIFF
--- a/internal/pluginregistry/plugin_config_merge.go
+++ b/internal/pluginregistry/plugin_config_merge.go
@@ -19,17 +19,19 @@ import (
 func buildCMKConfigOverrides(cfg *config.Config) (map[string]map[string]any, error) {
 	overrides := make(map[string]map[string]any)
 
-	if len(cfg.KeystorePool.SupportedRegions) > 0 {
-		wrapped, err := json.Marshal(map[string]any{"regions": cfg.KeystorePool.SupportedRegions})
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal supported regions: %w", err)
-		}
-		overrides[servicewrapper.KeystoreManagementType] = map[string]any{
-			"supportedregions": commoncfg.SourceRef{
-				Source: commoncfg.EmbeddedSourceValue,
-				Value:  string(wrapped),
-			},
-		}
+	regions := cfg.KeystorePool.SupportedRegions
+	if regions == nil {
+		regions = []config.Region{}
+	}
+	wrapped, err := json.Marshal(map[string]any{"regions": regions})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal supported regions: %w", err)
+	}
+	overrides[servicewrapper.KeystoreManagementType] = map[string]any{
+		"supportedregions": commoncfg.SourceRef{
+			Source: commoncfg.EmbeddedSourceValue,
+			Value:  string(wrapped),
+		},
 	}
 
 	return overrides, nil

--- a/internal/pluginregistry/plugin_config_merge_test.go
+++ b/internal/pluginregistry/plugin_config_merge_test.go
@@ -150,7 +150,20 @@ func TestBuildCMKConfigOverrides_NoRegionsConfigured(t *testing.T) {
 	overrides, err := cmkpluginregistry.BuildCMKConfigOverrides(cfg)
 	require.NoError(t, err)
 
-	assert.Empty(t, overrides)
+	keystoreOverrides, ok := overrides[servicewrapper.KeystoreManagementType]
+	require.True(t, ok, "override must always be present even with no regions")
+
+	sr, ok := keystoreOverrides["supportedregions"].(commoncfg.SourceRef)
+	require.True(t, ok)
+
+	raw, err := commoncfg.LoadValueFromSourceRef(sr)
+	require.NoError(t, err)
+
+	var wrapped map[string]any
+	require.NoError(t, json.Unmarshal(raw, &wrapped))
+	regions, ok := wrapped["regions"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, regions)
 }
 
 func TestBuildCMKConfigOverrides_YAMLRoundTrip(t *testing.T) {


### PR DESCRIPTION
Prevents components from failed startup even if they don't use keystore management plugin.