### PR TITLE
feat: introduce HYOK PENDING_REGISTRATION state

### DIFF
--- a/internal/api/cmkapi/cmkapi.go
+++ b/internal/api/cmkapi/cmkapi.go
@@ -71,9 +71,10 @@ const (
 	KeyStateENABLED         KeyState = "ENABLED"
 	KeyStateERROR           KeyState = "ERROR"
 	KeyStateFORBIDDEN       KeyState = "FORBIDDEN"
-	KeyStatePENDINGCREATION KeyState = "PENDING_CREATION"
-	KeyStatePENDINGDELETION KeyState = "PENDING_DELETION"
-	KeyStatePENDINGIMPORT   KeyState = "PENDING_IMPORT"
+	KeyStatePENDINGCREATION    KeyState = "PENDING_CREATION"
+	KeyStatePENDINGDELETION    KeyState = "PENDING_DELETION"
+	KeyStatePENDINGIMPORT      KeyState = "PENDING_IMPORT"
+	KeyStatePENDINGREGISTRATION KeyState = "PENDING_REGISTRATION"
 	KeyStateUNKNOWN         KeyState = "UNKNOWN"
 )
 
@@ -99,6 +100,8 @@ func (e KeyState) Valid() bool {
 	case KeyStatePENDINGDELETION:
 		return true
 	case KeyStatePENDINGIMPORT:
+		return true
+	case KeyStatePENDINGREGISTRATION:
 		return true
 	case KeyStateUNKNOWN:
 		return true
@@ -644,7 +647,7 @@ type Key struct {
 	// Region The region where the key is stored
 	Region *KeyRegion `json:"region,omitempty"`
 
-	// State Indicates the current state of the Key/Key Version. In addition to ENABLED and DISABLED states, the states PENDING_DELETION, DELETED, FORBIDDEN and UNKNOWN are applicable only to customer held keys. Keys and Versions are in UNKNOWN state if the authentication to the customer key fails due to any reason or when key detach has previously failed. FORBIDDEN state is for when a HYOK customer key permission is not granted to the system. DETACHING/DETACHED state is applicable for keys that have been marked with a detach call on tenant termination. PENDING_CREATION is a transient state for BYOK keys where provider-side prerequisites are still being set up. ERROR is a terminal failure state for keys that could not be provisioned within the timeout.
+	// State Indicates the current state of the Key/Key Version. In addition to ENABLED and DISABLED states, the states PENDING_DELETION, DELETED, FORBIDDEN and UNKNOWN are applicable only to customer held keys. Keys and Versions are in UNKNOWN state if the authentication to the customer key fails due to any reason or when key detach has previously failed. FORBIDDEN state is for when a HYOK customer key permission is not granted to the system. DETACHING/DETACHED state is applicable for keys that have been marked with a detach call on tenant termination. PENDING_CREATION is a transient state for BYOK keys where provider-side prerequisites are still being set up. PENDING_REGISTRATION is a transient state for HYOK keys where the initial authentication to the customer keystore failed and a retry loop is in progress. ERROR is a terminal failure state for keys that could not be provisioned within the timeout.
 	State *KeyState `json:"state,omitempty"`
 
 	// Type The type of the Key.
@@ -711,7 +714,7 @@ type KeyCommon struct {
 	// key identifier in full URL format.
 	NativeID *string `json:"nativeID,omitempty"`
 
-	// State Indicates the current state of the Key/Key Version. In addition to ENABLED and DISABLED states, the states PENDING_DELETION, DELETED, FORBIDDEN and UNKNOWN are applicable only to customer held keys. Keys and Versions are in UNKNOWN state if the authentication to the customer key fails due to any reason or when key detach has previously failed. FORBIDDEN state is for when a HYOK customer key permission is not granted to the system. DETACHING/DETACHED state is applicable for keys that have been marked with a detach call on tenant termination. PENDING_CREATION is a transient state for BYOK keys where provider-side prerequisites are still being set up. ERROR is a terminal failure state for keys that could not be provisioned within the timeout.
+	// State Indicates the current state of the Key/Key Version. In addition to ENABLED and DISABLED states, the states PENDING_DELETION, DELETED, FORBIDDEN and UNKNOWN are applicable only to customer held keys. Keys and Versions are in UNKNOWN state if the authentication to the customer key fails due to any reason or when key detach has previously failed. FORBIDDEN state is for when a HYOK customer key permission is not granted to the system. DETACHING/DETACHED state is applicable for keys that have been marked with a detach call on tenant termination. PENDING_CREATION is a transient state for BYOK keys where provider-side prerequisites are still being set up. PENDING_REGISTRATION is a transient state for HYOK keys where the initial authentication to the customer keystore failed and a retry loop is in progress. ERROR is a terminal failure state for keys that could not be provisioned within the timeout.
 	State *KeyState `json:"state,omitempty"`
 
 	// Type The type of the Key.
@@ -872,7 +875,7 @@ type KeyProvider = string
 // KeyRegion The region where the key is stored
 type KeyRegion = string
 
-// KeyState Indicates the current state of the Key/Key Version. In addition to ENABLED and DISABLED states, the states PENDING_DELETION, DELETED, FORBIDDEN and UNKNOWN are applicable only to customer held keys. Keys and Versions are in UNKNOWN state if the authentication to the customer key fails due to any reason or when key detach has previously failed. FORBIDDEN state is for when a HYOK customer key permission is not granted to the system. DETACHING/DETACHED state is applicable for keys that have been marked with a detach call on tenant termination. PENDING_CREATION is a transient state for BYOK keys where provider-side prerequisites are still being set up. ERROR is a terminal failure state for keys that could not be provisioned within the timeout.
+// KeyState Indicates the current state of the Key/Key Version. In addition to ENABLED and DISABLED states, the states PENDING_DELETION, DELETED, FORBIDDEN and UNKNOWN are applicable only to customer held keys. Keys and Versions are in UNKNOWN state if the authentication to the customer key fails due to any reason or when key detach has previously failed. FORBIDDEN state is for when a HYOK customer key permission is not granted to the system. DETACHING/DETACHED state is applicable for keys that have been marked with a detach call on tenant termination. PENDING_CREATION is a transient state for BYOK keys where provider-side prerequisites are still being set up. PENDING_REGISTRATION is a transient state for HYOK keys where the initial authentication to the customer keystore failed and a retry loop is in progress. ERROR is a terminal failure state for keys that could not be provisioned within the timeout.
 type KeyState string
 
 // KeyTotalVersions The number of Versions of the Key
@@ -900,7 +903,7 @@ type KeyVersion struct {
 	// NativeID The native identifier of the key material version.
 	NativeID *string `json:"nativeID,omitempty"`
 
-	// State Indicates the current state of the Key/Key Version. In addition to ENABLED and DISABLED states, the states PENDING_DELETION, DELETED, FORBIDDEN and UNKNOWN are applicable only to customer held keys. Keys and Versions are in UNKNOWN state if the authentication to the customer key fails due to any reason or when key detach has previously failed. FORBIDDEN state is for when a HYOK customer key permission is not granted to the system. DETACHING/DETACHED state is applicable for keys that have been marked with a detach call on tenant termination. PENDING_CREATION is a transient state for BYOK keys where provider-side prerequisites are still being set up. ERROR is a terminal failure state for keys that could not be provisioned within the timeout.
+	// State Indicates the current state of the Key/Key Version. In addition to ENABLED and DISABLED states, the states PENDING_DELETION, DELETED, FORBIDDEN and UNKNOWN are applicable only to customer held keys. Keys and Versions are in UNKNOWN state if the authentication to the customer key fails due to any reason or when key detach has previously failed. FORBIDDEN state is for when a HYOK customer key permission is not granted to the system. DETACHING/DETACHED state is applicable for keys that have been marked with a detach call on tenant termination. PENDING_CREATION is a transient state for BYOK keys where provider-side prerequisites are still being set up. PENDING_REGISTRATION is a transient state for HYOK keys where the initial authentication to the customer keystore failed and a retry loop is in progress. ERROR is a terminal failure state for keys that could not be provisioned within the timeout.
 	State *KeyState `json:"state,omitempty"`
 }
 

--- a/internal/async/tasks/pending_state_sync.go
+++ b/internal/async/tasks/pending_state_sync.go
@@ -18,11 +18,12 @@ import (
 // PendingStateUpdater is implemented by KeyManager.
 type PendingStateUpdater interface {
 	SyncPendingCreationKey(ctx context.Context, keyID uuid.UUID) error
+	SyncPendingRegistrationKey(ctx context.Context, keyID uuid.UUID) error
 }
 
 // PendingStateSync is an on-demand per-key task that processes a single key in
-// PENDING_CREATION state. It completes provisioning once provider-side prerequisites
-// are met, or transitions the key to ERROR on hard timeout.
+// PENDING_CREATION or PENDING_REGISTRATION state. It drives provisioning or auth
+// retry until success, or transitions the key to ERROR/FORBIDDEN on hard timeout.
 type PendingStateSync struct {
 	keyClient PendingStateUpdater
 	repo      repo.Repo
@@ -55,7 +56,14 @@ func (h *PendingStateSync) ProcessTask(ctx context.Context, task *asynq.Task) er
 
 	log.Info(ctx, "Starting pending state sync task", slog.String("keyID", keyID.String()))
 
+	// Each sync function guards its own state and no-ops if the key is not in the
+	// expected state. Try both pending states; at most one will do real work.
 	if err := h.keyClient.SyncPendingCreationKey(ctx, keyID); err != nil {
+		log.Info(ctx, "Pending state sync will retry", slog.String("keyID", keyID.String()), log.ErrorAttr(err))
+		return err
+	}
+
+	if err := h.keyClient.SyncPendingRegistrationKey(ctx, keyID); err != nil {
 		log.Info(ctx, "Pending state sync will retry", slog.String("keyID", keyID.String()), log.ErrorAttr(err))
 		return err
 	}

--- a/internal/async/tasks/pending_state_sync_test.go
+++ b/internal/async/tasks/pending_state_sync_test.go
@@ -29,6 +29,10 @@ func (m *pendingStateUpdaterMock) SyncPendingCreationKey(_ context.Context, _ uu
 	return m.err
 }
 
+func (m *pendingStateUpdaterMock) SyncPendingRegistrationKey(_ context.Context, _ uuid.UUID) error {
+	return m.err
+}
+
 func TestPendingStateSync(t *testing.T) {
 	db, _, _ := testutils.NewTestDB(t, testutils.TestDBConfig{})
 	r := sql.NewRepository(db)
@@ -70,7 +74,7 @@ func TestPendingStateSync(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("should return error when SyncPendingCreationKey fails", func(t *testing.T) {
+	t.Run("should return error when sync fails", func(t *testing.T) {
 		mock := &pendingStateUpdaterMock{err: errMockSyncPendingKey}
 		handler := tasks.NewPendingStateSync(mock, r)
 

--- a/internal/manager/errors.go
+++ b/internal/manager/errors.go
@@ -14,6 +14,7 @@ var (
 	ErrConfigNotFound          = errors.New("config not found")
 	ErrKeyCreationFailed       = errors.New("failed to create key in provider")
 	ErrKeyRegistration         = errors.New("failed to register key from provider")
+	ErrKeyRegistrationAuthFailed = errors.New("HYOK key registration failed: authentication error, pending async retry")
 	ErrUnsupportedKeyAlgorithm = errors.New("unsupported key algorithm")
 	ErrInvalidKeyState         = errors.New("invalid key state")
 	ErrHYOKKeyActionNotAllowed = errors.New("HYOK key action not allowed")

--- a/internal/manager/export_test.go
+++ b/internal/manager/export_test.go
@@ -133,4 +133,7 @@ var CreateKeyMaxDelay = &createKeyMaxDelay
 // PendingCreationTimeout exposes the package-level pending creation timeout so tests can override it.
 var PendingCreationTimeout = &pendingCreationTimeout
 
+// PendingRegistrationTimeout exposes the package-level pending registration timeout so tests can override it.
+var PendingRegistrationTimeout = &pendingRegistrationTimeout
+
 const DefaultKeystoreCertInfix = defaultKeystoreCertInfix

--- a/internal/manager/key.go
+++ b/internal/manager/key.go
@@ -63,6 +63,11 @@ var (
 	// After this duration without successful provisioning, the key transitions to ERROR.
 	// It is a var (not const) so tests can override it.
 	pendingCreationTimeout = 15 * time.Minute
+
+	// pendingRegistrationTimeout is the hard timeout for PENDING_REGISTRATION keys.
+	// After this duration without successful auth, the key transitions to FORBIDDEN.
+	// It is a var (not const) so tests can override it.
+	pendingRegistrationTimeout = 15 * time.Minute
 )
 
 var UnavailableKeyStates = []cmkapi.KeyState{
@@ -71,6 +76,7 @@ var UnavailableKeyStates = []cmkapi.KeyState{
 	cmkapi.KeyStateFORBIDDEN,
 	cmkapi.KeyStateUNKNOWN,
 	cmkapi.KeyStatePENDINGCREATION,
+	cmkapi.KeyStatePENDINGREGISTRATION,
 	cmkapi.KeyStateERROR,
 }
 
@@ -156,6 +162,9 @@ func (km *KeyManager) Create(
 	// Create or register key based on type
 	keyResp, err := km.createOrRegisterProviderKey(ctx, key, provider)
 	if err != nil {
+		if errors.Is(err, ErrKeyRegistrationAuthFailed) {
+			return km.createPendingRegistrationHYOKKey(ctx, key)
+		}
 		return nil, err
 	}
 
@@ -202,9 +211,12 @@ func (km *KeyManager) Get(ctx context.Context, keyID uuid.UUID) (*model.Key, err
 	switch key.KeyType {
 	case cmkapi.KeyTypeBYOK:
 	case cmkapi.KeyTypeHYOK:
-		err := km.syncHYOKKeyState(ctx, key)
-		if err != nil {
-			return nil, err
+		// Skip live sync for PENDING_REGISTRATION: the async loop handles state transitions.
+		if key.State != cmkapi.KeyStatePENDINGREGISTRATION {
+			err := km.syncHYOKKeyState(ctx, key)
+			if err != nil {
+				return nil, err
+			}
 		}
 	default:
 		return nil, ErrInvalidKeystore
@@ -268,7 +280,7 @@ func (km *KeyManager) UpdateKey(ctx context.Context, keyID uuid.UUID, keyPatch c
 
 	ctx = model.LogInjectKey(ctx, key)
 
-	if key.State == cmkapi.KeyStatePENDINGCREATION && keyPatch.Enabled != nil {
+	if (key.State == cmkapi.KeyStatePENDINGCREATION || key.State == cmkapi.KeyStatePENDINGREGISTRATION) && keyPatch.Enabled != nil {
 		return nil, ErrKeyInPendingState
 	}
 
@@ -412,7 +424,9 @@ func (km *KeyManager) ImportKeyMaterial(
 func (km *KeyManager) SyncHYOKKeys(ctx context.Context) error {
 	baseQuery := repo.NewQuery().Where(
 		repo.NewCompositeKeyGroup(
-			repo.NewCompositeKey().Where(repo.KeyTypeField, cmkapi.KeyTypeHYOK),
+			repo.NewCompositeKey().
+				Where(repo.KeyTypeField, cmkapi.KeyTypeHYOK).
+				Where(repo.StateField, cmkapi.KeyStatePENDINGREGISTRATION, repo.NotEq),
 		),
 	)
 
@@ -444,6 +458,85 @@ func (km *KeyManager) SyncPendingCreationKey(ctx context.Context, keyID uuid.UUI
 		return nil
 	}
 	return km.syncPendingCreationKey(ctx, key)
+}
+
+// SyncPendingRegistrationKey processes a single HYOK key in PENDING_REGISTRATION state.
+// It re-attempts GetKey to check if auth now succeeds, transitioning to ENABLED/DISABLED on success,
+// ERROR on non-auth failure, or FORBIDDEN on hard timeout.
+func (km *KeyManager) SyncPendingRegistrationKey(ctx context.Context, keyID uuid.UUID) error {
+	key, err := km.Get(ctx, keyID)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			log.Debug(ctx, "PENDING_REGISTRATION key no longer exists, skipping sync", slog.String("keyID", keyID.String()))
+			return nil
+		}
+		return errs.Wrap(ErrGetKeyDB, err)
+	}
+	if key.State != cmkapi.KeyStatePENDINGREGISTRATION {
+		return nil
+	}
+	return km.syncPendingRegistrationKey(ctx, key)
+}
+
+func (km *KeyManager) syncPendingRegistrationKey(ctx context.Context, key *model.Key) error {
+	ctx = model.LogInjectKey(ctx, key)
+	elapsed := time.Since(key.CreatedAt)
+	ctx = slogctx.With(ctx, slog.Duration("elapsed", elapsed.Round(time.Second)))
+
+	if elapsed > pendingRegistrationTimeout {
+		log.Error(ctx, "PENDING_REGISTRATION key timed out, transitioning to FORBIDDEN", ErrProvisioningTimeout)
+		return km.transitionPendingKeyToForbidden(ctx, key)
+	}
+
+	log.Debug(ctx, "Attempting to resolve PENDING_REGISTRATION key",
+		slog.Duration("timeout", pendingRegistrationTimeout))
+
+	provider, err := km.GetOrInitProvider(ctx, key)
+	if err != nil {
+		return err // retryable
+	}
+
+	keyResp, err := km.registerHYOKKey(ctx, key, provider)
+	if err != nil {
+		if errors.Is(err, ErrKeyRegistrationAuthFailed) {
+			log.Debug(ctx, "Auth still failing for PENDING_REGISTRATION key, will retry")
+			return err // retryable: Asynq retries on non-nil error
+		}
+		// Static validation failed (invalid state, unsupported algorithm, key not found, etc.) → ERROR
+		return km.transitionPendingKeyToError(ctx, key, "REGISTRATION_FAILED", err.Error())
+	}
+
+	// Auth succeeded and key validated — persist final state and set primary if first key.
+	err = km.repo.Transaction(ctx, func(ctx context.Context) error {
+		if err := km.setPrimaryIfFirstKey(ctx, key); err != nil {
+			return errs.Wrap(ErrUpdatePrimary, err)
+		}
+		_, err := km.repo.Patch(ctx, key, *repo.NewQuery().UpdateAll(true))
+		if err != nil {
+			return errs.Wrap(ErrUpdateKeyDB, err)
+		}
+		if keyResp != nil {
+			if err := km.syncKeyVersion(ctx, key, keyResp); err != nil {
+				log.Warn(ctx, "Failed to sync key version for PENDING_REGISTRATION key", log.ErrorAttr(err))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Debug(ctx, "PENDING_REGISTRATION key transitioned", slog.String("newState", string(key.State)))
+	return nil
+}
+
+func (km *KeyManager) transitionPendingKeyToForbidden(ctx context.Context, key *model.Key) error {
+	key.State = cmkapi.KeyStateFORBIDDEN
+	_, err := km.repo.Patch(ctx, key, *repo.NewQuery().UpdateAll(true))
+	if err != nil {
+		return errs.Wrap(ErrUpdateKeyDB, err)
+	}
+	return nil
 }
 
 func (km *KeyManager) Detach(ctx context.Context, key *model.Key) error {
@@ -569,6 +662,18 @@ func (km *KeyManager) createPendingBYOKKeyIfNeeded(ctx context.Context, key *mod
 	km.sendCreateAuditLog(ctx, key)
 	km.enqueuePendingStateSync(ctx, key)
 	return true, nil
+}
+
+func (km *KeyManager) createPendingRegistrationHYOKKey(ctx context.Context, key *model.Key) (*model.Key, error) {
+	key.State = cmkapi.KeyStatePENDINGREGISTRATION
+	if err := km.repo.Transaction(ctx, func(ctx context.Context) error {
+		return km.repo.Create(ctx, key)
+	}); err != nil {
+		return nil, errs.Wrap(ErrCreateKeyDB, err)
+	}
+	km.sendCreateAuditLog(ctx, key)
+	km.enqueuePendingStateSync(ctx, key)
+	return key, nil
 }
 
 func (km *KeyManager) applyKeyPatch(
@@ -910,6 +1015,9 @@ func (km *KeyManager) registerHYOKKey(
 		},
 	})
 	if err != nil {
+		if errors.Is(err, keymanagement.ErrProviderAuthenticationFailed) {
+			return nil, ErrKeyRegistrationAuthFailed
+		}
 		return nil, errs.Wrap(ErrKeyRegistration, err)
 	}
 
@@ -1107,8 +1215,8 @@ func (km *KeyManager) setPrimaryIfFirstKey(ctx context.Context, key *model.Key) 
 
 	// Update keyconfig primaryKey
 	if !exist {
-		if key.State == cmkapi.KeyStatePENDINGCREATION {
-			return nil // Not primary yet; skip until creation completes
+		if key.State == cmkapi.KeyStatePENDINGCREATION || key.State == cmkapi.KeyStatePENDINGREGISTRATION {
+			return nil // Not primary yet; skip until provisioning/registration completes
 		}
 		if key.State == cmkapi.KeyStateDISABLED {
 			return ErrKeyIsNotEnabled

--- a/internal/manager/key_test.go
+++ b/internal/manager/key_test.go
@@ -256,8 +256,8 @@ func TestCreate(t *testing.T) {
 					k.Provider = providerTest
 				})
 			},
-			wantErr: true,
-			errMsg:  "failed to authenticate with the keystore provider",
+			wantErr:   false,
+			wantState: cmkapi.KeyStatePENDINGREGISTRATION,
 		},
 		{
 			name: "HYOK key creation key not found",
@@ -2203,4 +2203,313 @@ func SetupKeyTestWithAsyncClient(
 	ctx = testutils.InjectBusinessUserDataIntoContext(ctx, uuid.NewString(), []string{keyConfig.AdminGroup.IAMIdentifier})
 
 	return km, r, ctx, keyConfig
+}
+
+// createTestHYOKKeyDirect persists a HYOK key directly in the given state,
+// bypassing the manager's Create flow. Used for PENDING_REGISTRATION sync tests.
+func createTestHYOKKeyDirect(t *testing.T, r repo.Repo, ctx context.Context, keyConfigID uuid.UUID, state cmkapi.KeyState) *model.Key {
+	t.Helper()
+	hyokInfo, err := json.Marshal(testutils.ValidKeystoreAccountInfo)
+	require.NoError(t, err)
+
+	cryptoAccessData := model.KeyAccessData{
+		"crypto-1": {
+			CertificateSubject: new("CN=test_tenant0,OU=OU1/OU2,O=TestOrg,L=Berlin,C=DE"),
+			AdditionalProperties: map[string]any{
+				"someKey": "someValue",
+			},
+		},
+	}
+	cryptoBytes, err := json.Marshal(cryptoAccessData)
+	require.NoError(t, err)
+
+	key := testutils.NewKey(func(k *model.Key) {
+		k.KeyConfigurationID = keyConfigID
+		k.KeyType = cmkapi.KeyTypeHYOK
+		k.State = state
+		k.NativeID = new("mock-key/11111111")
+		k.ManagementAccessData = hyokInfo
+		k.Provider = providerTest
+		k.CryptoAccessData = cryptoBytes
+	})
+	testutils.CreateTestEntities(ctx, t, r, key)
+	return key
+}
+
+func TestCreateHYOKPendingRegistration(t *testing.T) {
+	t.Run("HYOK key is created in PENDING_REGISTRATION when GetKey returns auth error", func(t *testing.T) {
+		// Use invalid credentials to trigger ErrProviderAuthenticationFailed on GetKey.
+		invalidInfo, err := json.Marshal(map[string]string{"AccountID": "bad", "UserID": "bad"})
+		require.NoError(t, err)
+		cryptoAccessData := model.KeyAccessData{"crypto-1": {AdditionalProperties: map[string]any{"someKey": "someValue"}}}
+		cryptoBytes, err := json.Marshal(cryptoAccessData)
+		require.NoError(t, err)
+
+		km, r, ctx, keyConfig := SetupKeyTest(t)
+		seedDefaultKeystore(t, r, ctx)
+
+		key := testutils.NewKey(func(k *model.Key) {
+			k.KeyConfigurationID = keyConfig.ID
+			k.KeyType = cmkapi.KeyTypeHYOK
+			k.NativeID = new("mock-key/11111111")
+			k.ManagementAccessData = invalidInfo
+			k.Provider = providerTest
+			k.CryptoAccessData = cryptoBytes
+		})
+
+		result, err := km.Create(ctx, key)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, cmkapi.KeyStatePENDINGREGISTRATION, result.State)
+
+		dbKey := &model.Key{ID: result.ID}
+		found, dbErr := r.First(ctx, dbKey, *repo.NewQuery())
+		require.NoError(t, dbErr)
+		require.True(t, found)
+		assert.Equal(t, cmkapi.KeyStatePENDINGREGISTRATION, dbKey.State)
+	})
+
+	t.Run("PENDING_REGISTRATION HYOK key is not set as primary", func(t *testing.T) {
+		invalidInfo, err := json.Marshal(map[string]string{"AccountID": "bad", "UserID": "bad"})
+		require.NoError(t, err)
+		cryptoAccessData := model.KeyAccessData{"crypto-1": {AdditionalProperties: map[string]any{"someKey": "someValue"}}}
+		cryptoBytes, err := json.Marshal(cryptoAccessData)
+		require.NoError(t, err)
+
+		km, r, ctx, keyConfig := SetupKeyTest(t)
+		seedDefaultKeystore(t, r, ctx)
+
+		freshKeyConfig := testutils.NewKeyConfig(func(_ *model.KeyConfiguration) {})
+		testutils.CreateTestEntities(ctx, t, r, freshKeyConfig)
+		localCtx := testutils.InjectBusinessUserDataIntoContext(
+			ctx, uuid.NewString(),
+			[]string{freshKeyConfig.AdminGroup.IAMIdentifier, keyConfig.AdminGroup.IAMIdentifier},
+		)
+
+		key := testutils.NewKey(func(k *model.Key) {
+			k.KeyConfigurationID = freshKeyConfig.ID
+			k.KeyType = cmkapi.KeyTypeHYOK
+			k.NativeID = new("mock-key/11111111")
+			k.ManagementAccessData = invalidInfo
+			k.Provider = providerTest
+			k.CryptoAccessData = cryptoBytes
+		})
+
+		result, err := km.Create(localCtx, key)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, cmkapi.KeyStatePENDINGREGISTRATION, result.State)
+
+		kc := &model.KeyConfiguration{ID: freshKeyConfig.ID}
+		found, dbErr := r.First(localCtx, kc, *repo.NewQuery())
+		require.NoError(t, dbErr)
+		require.True(t, found)
+		assert.Nil(t, kc.PrimaryKeyID, "PENDING_REGISTRATION key must not become primary")
+	})
+
+	t.Run("HYOK key creation rejects synchronously when key is not in ENABLED state", func(t *testing.T) {
+		// Plugin returns DISABLED for this key — static validation, not auth error.
+		disabledPlugin := testplugins.NewTestKeyManagement(true, false)
+		disabledPlugin.HandleKeyRecord("mock-key/disabled-key", testplugins.DisabledKeyStatus)
+
+		km, r, ctx, keyConfig := SetupKeyTest(t, testplugins.WithKeyManagement(testplugins.Name, disabledPlugin))
+		seedDefaultKeystore(t, r, ctx)
+
+		hyokInfo, err := json.Marshal(testutils.ValidKeystoreAccountInfo)
+		require.NoError(t, err)
+		cryptoAccessData := model.KeyAccessData{"crypto-1": {AdditionalProperties: map[string]any{"someKey": "someValue"}}}
+		cryptoBytes, err := json.Marshal(cryptoAccessData)
+		require.NoError(t, err)
+
+		key := testutils.NewKey(func(k *model.Key) {
+			k.KeyConfigurationID = keyConfig.ID
+			k.KeyType = cmkapi.KeyTypeHYOK
+			k.NativeID = new("mock-key/disabled-key")
+			k.ManagementAccessData = hyokInfo
+			k.Provider = providerTest
+			k.CryptoAccessData = cryptoBytes
+		})
+
+		result, err := km.Create(ctx, key)
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, manager.ErrInvalidKeyState, "disabled key must be rejected synchronously")
+	})
+}
+
+func TestUpdateKeyPendingRegistrationGuard(t *testing.T) {
+	km, r, ctx, keyConfig := SetupKeyTest(t)
+
+	t.Run("enable/disable rejected when key is in PENDING_REGISTRATION state", func(t *testing.T) {
+		key := createTestHYOKKeyDirect(t, r, ctx, keyConfig.ID, cmkapi.KeyStatePENDINGREGISTRATION)
+
+		_, err := km.UpdateKey(ctx, key.ID, cmkapi.KeyPatch{Enabled: new(true)})
+
+		assert.ErrorIs(t, err, manager.ErrKeyInPendingState)
+	})
+
+	t.Run("name update allowed on PENDING_REGISTRATION key", func(t *testing.T) {
+		key := createTestHYOKKeyDirect(t, r, ctx, keyConfig.ID, cmkapi.KeyStatePENDINGREGISTRATION)
+		newName := uuid.NewString()
+
+		result, err := km.UpdateKey(ctx, key.ID, cmkapi.KeyPatch{Name: new(newName)})
+
+		require.NoError(t, err)
+		assert.Equal(t, newName, result.Name)
+	})
+}
+
+func TestSyncPendingRegistrationKey(t *testing.T) {
+	t.Run("transitions key to ENABLED when auth succeeds and key is enabled in keystore", func(t *testing.T) {
+		km, r, ctx, keyConfig := SetupKeyTest(t)
+
+		key := createTestHYOKKeyDirect(t, r, ctx, keyConfig.ID, cmkapi.KeyStatePENDINGREGISTRATION)
+
+		syncErr := km.SyncPendingRegistrationKey(ctx, key.ID)
+
+		require.NoError(t, syncErr)
+		dbKey := &model.Key{ID: key.ID}
+		found, err := r.First(ctx, dbKey, *repo.NewQuery())
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, cmkapi.KeyStateENABLED, dbKey.State,
+			"key should transition to ENABLED when auth succeeds")
+	})
+
+	t.Run("transitions key to ERROR when key not found in keystore", func(t *testing.T) {
+		km, r, ctx, keyConfig := SetupKeyTest(t)
+
+		hyokInfo, err := json.Marshal(testutils.ValidKeystoreAccountInfo)
+		require.NoError(t, err)
+		cryptoAccessData := model.KeyAccessData{"crypto-1": {AdditionalProperties: map[string]any{"someKey": "someValue"}}}
+		cryptoBytes, err := json.Marshal(cryptoAccessData)
+		require.NoError(t, err)
+
+		// NativeID points to a key that does not exist in the test keystore.
+		key := testutils.NewKey(func(k *model.Key) {
+			k.KeyConfigurationID = keyConfig.ID
+			k.KeyType = cmkapi.KeyTypeHYOK
+			k.State = cmkapi.KeyStatePENDINGREGISTRATION
+			k.NativeID = new("mock-key/nonexistent")
+			k.ManagementAccessData = hyokInfo
+			k.Provider = providerTest
+			k.CryptoAccessData = cryptoBytes
+		})
+		testutils.CreateTestEntities(ctx, t, r, key)
+
+		syncErr := km.SyncPendingRegistrationKey(ctx, key.ID)
+
+		require.NoError(t, syncErr, "non-retryable failure should be handled internally (no error returned)")
+		dbKey := &model.Key{ID: key.ID}
+		found, dbErr := r.First(ctx, dbKey, *repo.NewQuery())
+		require.NoError(t, dbErr)
+		require.True(t, found)
+		assert.Equal(t, cmkapi.KeyStateERROR, dbKey.State,
+			"key should transition to ERROR when key not found in keystore")
+	})
+
+	t.Run("returns error (retryable) when auth still fails", func(t *testing.T) {
+		km, r, ctx, keyConfig := SetupKeyTest(t)
+
+		invalidInfo, err := json.Marshal(map[string]string{"AccountID": "bad", "UserID": "bad"})
+		require.NoError(t, err)
+		cryptoAccessData := model.KeyAccessData{"crypto-1": {AdditionalProperties: map[string]any{"someKey": "someValue"}}}
+		cryptoBytes, err := json.Marshal(cryptoAccessData)
+		require.NoError(t, err)
+
+		key := testutils.NewKey(func(k *model.Key) {
+			k.KeyConfigurationID = keyConfig.ID
+			k.KeyType = cmkapi.KeyTypeHYOK
+			k.State = cmkapi.KeyStatePENDINGREGISTRATION
+			k.NativeID = new("mock-key/11111111")
+			k.ManagementAccessData = invalidInfo
+			k.Provider = providerTest
+			k.CryptoAccessData = cryptoBytes
+		})
+		testutils.CreateTestEntities(ctx, t, r, key)
+
+		syncErr := km.SyncPendingRegistrationKey(ctx, key.ID)
+
+		assert.Error(t, syncErr, "auth still failing should return error so Asynq retries")
+		assert.ErrorIs(t, syncErr, manager.ErrKeyRegistrationAuthFailed)
+
+		dbKey := &model.Key{ID: key.ID}
+		found, dbErr := r.First(ctx, dbKey, *repo.NewQuery())
+		require.NoError(t, dbErr)
+		require.True(t, found)
+		assert.Equal(t, cmkapi.KeyStatePENDINGREGISTRATION, dbKey.State,
+			"state must remain PENDING_REGISTRATION while auth is still failing")
+	})
+
+	t.Run("transitions key to FORBIDDEN on timeout", func(t *testing.T) {
+		original := *manager.PendingRegistrationTimeout
+		*manager.PendingRegistrationTimeout = time.Nanosecond
+		t.Cleanup(func() { *manager.PendingRegistrationTimeout = original })
+
+		km, r, ctx, keyConfig := SetupKeyTest(t)
+
+		key := createTestHYOKKeyDirect(t, r, ctx, keyConfig.ID, cmkapi.KeyStatePENDINGREGISTRATION)
+
+		time.Sleep(time.Millisecond)
+		syncErr := km.SyncPendingRegistrationKey(ctx, key.ID)
+
+		require.NoError(t, syncErr)
+		dbKey := &model.Key{ID: key.ID}
+		found, err := r.First(ctx, dbKey, *repo.NewQuery())
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, cmkapi.KeyStateFORBIDDEN, dbKey.State,
+			"key should transition to FORBIDDEN after timeout")
+	})
+}
+
+func TestSyncPendingRegistrationKeyEdgeCases(t *testing.T) {
+	t.Run("skips sync when key no longer exists", func(t *testing.T) {
+		km, _, ctx, _ := SetupKeyTest(t)
+
+		err := km.SyncPendingRegistrationKey(ctx, uuid.New())
+
+		require.NoError(t, err, "deleted key should be silently skipped")
+	})
+
+	t.Run("skips sync when key is not in PENDING_REGISTRATION state", func(t *testing.T) {
+		km, r, ctx, keyConfig := SetupKeyTest(t)
+
+		key := createTestHYOKKeyDirect(t, r, ctx, keyConfig.ID, cmkapi.KeyStateENABLED)
+
+		err := km.SyncPendingRegistrationKey(ctx, key.ID)
+
+		require.NoError(t, err, "non-PENDING_REGISTRATION key should be a no-op")
+	})
+}
+
+func TestSyncHYOKKeysExcludesPendingRegistration(t *testing.T) {
+	t.Run("PENDING_REGISTRATION keys are excluded from HYOK key-state-check loop", func(t *testing.T) {
+		km, r, ctx, keyConfig := SetupKeyTest(t)
+
+		enabledKey := createTestHYOKKeyDirect(t, r, ctx, keyConfig.ID, cmkapi.KeyStateENABLED)
+		pendingKey := createTestHYOKKeyDirect(t, r, ctx, keyConfig.ID, cmkapi.KeyStatePENDINGREGISTRATION)
+
+		syncErr := km.SyncHYOKKeys(ctx)
+
+		require.NoError(t, syncErr)
+
+		// PENDING_REGISTRATION key must remain unchanged.
+		dbPending := &model.Key{ID: pendingKey.ID}
+		found, err := r.First(ctx, dbPending, *repo.NewQuery())
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, cmkapi.KeyStatePENDINGREGISTRATION, dbPending.State,
+			"PENDING_REGISTRATION key must not be touched by SyncHYOKKeys")
+
+		// ENABLED key should still be ENABLED.
+		dbEnabled := &model.Key{ID: enabledKey.ID}
+		found, err = r.First(ctx, dbEnabled, *repo.NewQuery())
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, cmkapi.KeyStateENABLED, dbEnabled.State)
+	})
 }

--- a/migrations/tenant/schema/00017_add_pending_registration_key_state.sql
+++ b/migrations/tenant/schema/00017_add_pending_registration_key_state.sql
@@ -1,0 +1,19 @@
+-- Extends the keys state constraint to include PENDING_REGISTRATION.
+
+-- +goose Up
+ALTER TABLE keys DROP CONSTRAINT IF EXISTS chk_keys_state;
+ALTER TABLE keys ADD CONSTRAINT chk_keys_state
+    CHECK (state IN (
+        'ENABLED', 'DISABLED', 'PENDING_DELETION', 'DELETED', 'FORBIDDEN',
+        'UNKNOWN', 'PENDING_IMPORT', 'DETACHING', 'DETACHED',
+        'PENDING_CREATION', 'PENDING_REGISTRATION', 'ERROR'
+    )) NOT VALID;
+
+-- +goose Down
+ALTER TABLE keys DROP CONSTRAINT IF EXISTS chk_keys_state;
+ALTER TABLE keys ADD CONSTRAINT chk_keys_state
+    CHECK (state IN (
+        'ENABLED', 'DISABLED', 'PENDING_DELETION', 'DELETED', 'FORBIDDEN',
+        'UNKNOWN', 'PENDING_IMPORT', 'DETACHING', 'DETACHED',
+        'PENDING_CREATION', 'ERROR'
+    )) NOT VALID;


### PR DESCRIPTION
## Summary

- Adds `PENDING_REGISTRATION` as a new transient key state for HYOK keys whose initial `GetKey` call fails with an authentication error. Instead of rejecting the key synchronously, CMK persists it and retries asynchronously via the existing `PendingStateSync` Asynq task — mirroring the `PENDING_CREATION` pattern for BYOK.
- The retry loop drives the key to `ENABLED`/`DISABLED` on success, or to `FORBIDDEN` after a 15-minute hard timeout.
- Non-auth failures (key not found, wrong state, etc.) still reject synchronously so errors with clear root causes are surfaced immediately.
