### PR TITLE
KMS20-7312: limit inbound request body size to 1 MiB

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -204,6 +204,9 @@ func createHTTPServer(
 				middleware.InjectMultiTenancy(),
 				middleware.InjectRequestID(),
 				middleware.TracingMiddleware(cfg),
+				// RequestBodyLimitMiddleware runs before TracingMiddleware to cap body size
+				// before any part of the stack reads it.
+				middleware.RequestBodyLimitMiddleware(),
 				// SecurityHeadersMiddleware is last in the slice so it runs first (FILO order).
 				// Security headers must be set before any other middleware runs to ensure
 				// they appear on every response, including error responses.

--- a/internal/middleware/body_limit.go
+++ b/internal/middleware/body_limit.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+// maxRequestBodyBytes is the maximum allowed size for inbound request bodies.
+const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
+// RequestBodyLimitMiddleware caps inbound request body size to prevent memory
+// exhaustion from oversized payloads.
+func RequestBodyLimitMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/body_limit_test.go
+++ b/internal/middleware/body_limit_test.go
@@ -1,0 +1,67 @@
+package middleware_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openkcm/cmk/internal/middleware"
+)
+
+func TestRequestBodyLimitMiddleware(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           io.Reader
+		expectedStatus int
+		expectBody     bool
+	}{
+		{
+			name:           "body within limit is passed through",
+			body:           strings.NewReader("small body"),
+			expectedStatus: http.StatusOK,
+			expectBody:     true,
+		},
+		{
+			name:           "body exceeding 1 MiB is rejected",
+			body:           bytes.NewReader(make([]byte, 1<<20+1)),
+			expectedStatus: http.StatusRequestEntityTooLarge,
+			expectBody:     false,
+		},
+		{
+			name:           "body exactly at 1 MiB limit is passed through",
+			body:           bytes.NewReader(make([]byte, 1<<20)),
+			expectedStatus: http.StatusOK,
+			expectBody:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := io.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodPost, "/test", tt.body)
+			rr := httptest.NewRecorder()
+
+			mid := middleware.RequestBodyLimitMiddleware()(next)
+			mid.ServeHTTP(rr, req)
+
+			require.Equal(t, tt.expectedStatus, rr.Code)
+			if tt.expectBody {
+				assert.NotEmpty(t, rr.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **DSC-011 (MEDIUM)**: Add `RequestBodyLimitMiddleware` using `http.MaxBytesReader` to cap all inbound request bodies at 1 MiB before they reach the OAPI validator or any decoder. Wired into the middleware chain in `internal/daemon/server.go`.

Source: Frontier AI Wave 1 scan (SERVICE-2196)

## Test plan
- [ ] Middleware tests pass (`go test ./internal/middleware/...`)
- [ ] Requests with bodies under 1 MiB are handled normally
- [ ] Requests with bodies over 1 MiB are rejected with 413